### PR TITLE
Add localized ordinals from rails-i18n gem

### DIFF
--- a/lib/tmdb/web/translations/i18n.rb
+++ b/lib/tmdb/web/translations/i18n.rb
@@ -143,6 +143,13 @@ module TMDb
         File.dirname(__FILE__) + "/../../../../languages"
       end
 
+      # This list of ordinal localizations is sourced from the rails-i18n gem (v7.0.9)
+      # To update values, clone the repo and copy the rails/ordinals directory.
+      # https://github.com/svenfuchs/rails-i18n
+      def self.ordinal_path
+        File.dirname(__FILE__) + "/../../../../ordinals"
+      end
+
       def self.load_path
         File.dirname(__FILE__) + "/../../../../locales"
       end

--- a/lib/tmdb/web/translations/i18n_fallbacks.rb
+++ b/lib/tmdb/web/translations/i18n_fallbacks.rb
@@ -8,6 +8,8 @@ I18n::Backend::Simple.include I18n::Backend::Fallbacks
 I18n.load_path += Dir[TMDb::Web::Translations.load_path + '/*.yml']
 I18n.load_path += Dir[TMDb::Web::Translations.country_path + '/*.yml']
 I18n.load_path += Dir[TMDb::Web::Translations.language_path + '/*.yml']
+I18n.load_path += Dir[TMDb::Web::Translations.ordinal_path + '/*.rb']
+I18n.load_path += Dir[TMDb::Web::Translations.ordinal_path + '/*.yml']
 I18n.load_path += Dir[TMDb::Web::Translations.transliteration_path + '/*.rb']
 I18n.load_path += Dir[TMDb::Web::Translations.transliteration_path + '/*.yml']
 

--- a/ordinals/be.yml
+++ b/ordinals/be.yml
@@ -1,0 +1,6 @@
+---
+be:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/bs.yml
+++ b/ordinals/bs.yml
@@ -1,0 +1,6 @@
+---
+bs:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/cs.yml
+++ b/ordinals/cs.yml
@@ -1,0 +1,6 @@
+---
+cs:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/da.yml
+++ b/ordinals/da.yml
@@ -1,0 +1,6 @@
+---
+da:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/de-AT.yml
+++ b/ordinals/de-AT.yml
@@ -1,0 +1,6 @@
+---
+de-AT:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/de-CH.yml
+++ b/ordinals/de-CH.yml
@@ -1,0 +1,6 @@
+---
+de-CH:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/de-DE.yml
+++ b/ordinals/de-DE.yml
@@ -1,0 +1,6 @@
+---
+de-DE:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/de.yml
+++ b/ordinals/de.yml
@@ -1,0 +1,6 @@
+---
+de:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/eo.yml
+++ b/ordinals/eo.yml
@@ -1,0 +1,6 @@
+---
+eo:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/et.yml
+++ b/ordinals/et.yml
@@ -1,0 +1,6 @@
+---
+et:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/fa.yml
+++ b/ordinals/fa.yml
@@ -1,0 +1,6 @@
+---
+fa:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/fi.yml
+++ b/ordinals/fi.yml
@@ -1,0 +1,6 @@
+---
+fi:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/fr-CA.rb
+++ b/ordinals/fr-CA.rb
@@ -1,0 +1,19 @@
+{
+  "fr-CA": {
+    number: {
+      nth: {
+        ordinals: -> (_key, number:, **_options) {
+          if number.to_i.abs == 1
+            'er'
+          else
+            'e'
+          end
+        },
+
+        ordinalized:  -> (_key, number:, **_options) {
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        }
+      }
+    }
+  }
+}

--- a/ordinals/fr-CH.rb
+++ b/ordinals/fr-CH.rb
@@ -1,0 +1,19 @@
+{
+  "fr-CH": {
+    number: {
+      nth: {
+        ordinals: -> (_key, number:, **_options) {
+          if number.to_i.abs == 1
+            'er'
+          else
+            'e'
+          end
+        },
+
+        ordinalized:  -> (_key, number:, **_options) {
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        }
+      }
+    }
+  }
+}

--- a/ordinals/fr-FR.rb
+++ b/ordinals/fr-FR.rb
@@ -1,0 +1,19 @@
+{
+  "fr-FR": {
+    number: {
+      nth: {
+        ordinals: -> (_key, number:, **_options) {
+          if number.to_i.abs == 1
+            'er'
+          else
+            'e'
+          end
+        },
+
+        ordinalized:  -> (_key, number:, **_options) {
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        }
+      }
+    }
+  }
+}

--- a/ordinals/fr.rb
+++ b/ordinals/fr.rb
@@ -1,0 +1,19 @@
+{
+  fr: {
+    number: {
+      nth: {
+        ordinals: -> (_key, number:, **_options) {
+          if number.to_i.abs == 1
+            'er'
+          else
+            'e'
+          end
+        },
+
+        ordinalized:  -> (_key, number:, **_options) {
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        }
+      }
+    }
+  }
+}

--- a/ordinals/gd.rb
+++ b/ordinals/gd.rb
@@ -1,0 +1,24 @@
+{
+  gd: {
+    number: {
+      nth: {
+        ordinals: -> (_key, number:, **_options) {
+          case number.to_i.abs
+          when 1
+            'ᵈ'
+          when 2
+            'ⁿᵃ'
+          when 3
+            'ˢ'
+          else
+            'ᵐʰ'
+          end
+        },
+
+        ordinalized:  -> (_key, number:, **_options) {
+          "#{number}#{ActiveSupport::Inflector.ordinal(number)}"
+        }
+      }
+    }
+  }
+}

--- a/ordinals/hr.yml
+++ b/ordinals/hr.yml
@@ -1,0 +1,6 @@
+---
+hr:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/hu.yml
+++ b/ordinals/hu.yml
@@ -1,0 +1,6 @@
+---
+hu:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/is.yml
+++ b/ordinals/is.yml
@@ -1,0 +1,6 @@
+---
+is:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/ka.yml
+++ b/ordinals/ka.yml
@@ -1,0 +1,6 @@
+---
+ka:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/lb.yml
+++ b/ordinals/lb.yml
@@ -1,0 +1,6 @@
+---
+lb:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/lt.yml
+++ b/ordinals/lt.yml
@@ -1,0 +1,6 @@
+---
+lt:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/lv.yml
+++ b/ordinals/lv.yml
@@ -1,0 +1,6 @@
+---
+lv:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/mk.yml
+++ b/ordinals/mk.yml
@@ -1,0 +1,6 @@
+---
+mk:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/nb.yml
+++ b/ordinals/nb.yml
@@ -1,0 +1,6 @@
+---
+nb:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/ne.yml
+++ b/ordinals/ne.yml
@@ -1,0 +1,6 @@
+---
+ne:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/nn.yml
+++ b/ordinals/nn.yml
@@ -1,0 +1,6 @@
+---
+nn:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/pl.yml
+++ b/ordinals/pl.yml
@@ -1,0 +1,6 @@
+---
+pl:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/sk.yml
+++ b/ordinals/sk.yml
@@ -1,0 +1,6 @@
+---
+sk:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/sl.yml
+++ b/ordinals/sl.yml
@@ -1,0 +1,6 @@
+---
+sl:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/sq.yml
+++ b/ordinals/sq.yml
@@ -1,0 +1,6 @@
+---
+sq:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/sr.yml
+++ b/ordinals/sr.yml
@@ -1,0 +1,6 @@
+---
+sr:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/sw.yml
+++ b/ordinals/sw.yml
@@ -1,0 +1,6 @@
+---
+sw:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."

--- a/ordinals/tr.yml
+++ b/ordinals/tr.yml
@@ -1,0 +1,6 @@
+---
+tr:
+  number:
+    nth:
+      ordinals: "."
+      ordinalized: "%{number}."


### PR DESCRIPTION
**What does this do?**
This adds localizations for ordinals (eg. 1st, 2nd, 3rd, etc.) from the [`rails-i18n` gem](https://github.com/svenfuchs/rails-i18n).