### PR TITLE
Remove direct dependency on rails-i18n gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,6 @@ source "https://rubygems.org"
 gemspec
 
 gem "dotenv"
+gem "rails-i18n", require: false
 gem "rake", "~> 13.0"
 gem "rubocop", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     tmdb-web-translations (0.1.0)
       i18n
-      rails-i18n
 
 GEM
   remote: https://rubygems.org/
@@ -59,7 +58,7 @@ GEM
       reline (>= 0.4.2)
     json (2.9.1)
     language_server-protocol (3.17.0.3)
-    logger (1.6.5)
+    logger (1.7.0)
     loofah (2.24.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -111,7 +110,7 @@ GEM
       erb
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
-    reline (0.6.1)
+    reline (0.6.2)
       io-console (~> 0.5)
     rubocop (1.70.0)
       json (~> 2.3)
@@ -143,6 +142,7 @@ PLATFORMS
 
 DEPENDENCIES
   dotenv
+  rails-i18n
   rake (~> 13.0)
   rubocop (~> 1.7)
   tmdb-web-translations!

--- a/lib/rails_i18n/common_pluralizations/east_slavic.rb
+++ b/lib/rails_i18n/common_pluralizations/east_slavic.rb
@@ -1,0 +1,42 @@
+# Originally was implemented by Yaroslav Markin in "russian" gem
+# (http://github.com/yaroslav/russian)
+#
+# Used for Belarusian, Russian, Ukrainian.
+
+module RailsI18n
+  module Pluralization
+    module EastSlavic
+      FROM_2_TO_4   = (2..4).to_a.freeze
+      FROM_5_TO_9   = (5..9).to_a.freeze
+      FROM_11_TO_14 = (11..14).to_a.freeze
+      FROM_12_TO_14 = (12..14).to_a.freeze
+
+      def self.rule
+        lambda do |n|
+          return :other unless n.is_a?(Numeric)
+
+          mod10 = n % 10
+          mod100 = n % 100
+
+          if mod10 == 1 && mod100 != 11
+            :one
+          elsif FROM_2_TO_4.include?(mod10) && !FROM_12_TO_14.include?(mod100)
+            :few
+          elsif mod10 == 0 || FROM_5_TO_9.include?(mod10) || FROM_11_TO_14.include?(mod100)
+            :many
+          else
+            :other
+          end
+        end
+      end
+
+      def self.with_locale(locale)
+        { locale => {
+            :i18n => {
+              :plural => {
+                :keys => [:one, :few, :many, :other],
+                :rule => rule }}}}
+      end
+    end
+  end
+end

--- a/lib/rails_i18n/common_pluralizations/one_few_other.rb
+++ b/lib/rails_i18n/common_pluralizations/one_few_other.rb
@@ -1,0 +1,39 @@
+module RailsI18n
+  module Pluralization
+    module OneFewOther
+      FROM_2_TO_4   = (2..4).to_a.freeze
+      FROM_12_TO_14 = (12..14).to_a.freeze
+
+      def self.rule
+        lambda do |n|
+          return :other unless n.is_a?(Numeric)
+
+          frac = (n.to_d % 1)
+
+          if frac.nonzero?
+            n = frac.to_s.split('.').last.to_i
+          end
+
+          mod10 = n % 10
+          mod100 = n % 100
+
+          if mod10 == 1 && mod100 != 11
+            :one
+          elsif FROM_2_TO_4.include?(mod10) && !FROM_12_TO_14.include?(mod100)
+            :few
+          else
+            :other
+          end
+        end
+      end
+
+      def self.with_locale(locale)
+          { locale => {
+              :i18n => {
+                :plural => {
+                  :keys => [:one, :few, :other],
+                  :rule => rule }}}}
+      end
+    end
+  end
+end

--- a/lib/rails_i18n/common_pluralizations/one_other.rb
+++ b/lib/rails_i18n/common_pluralizations/one_other.rb
@@ -1,0 +1,19 @@
+# Used as "default" pluralization rule
+
+module RailsI18n
+  module Pluralization
+    module OneOther
+      def self.rule
+        lambda { |n| n == 1 ? :one : :other }
+      end
+
+      def self.with_locale(locale)
+        { locale => {
+            :'i18n' => {
+              :plural => {
+                :keys => [:one, :other],
+                :rule => rule }}}}
+      end
+    end
+  end
+end

--- a/lib/rails_i18n/common_pluralizations/one_two_other.rb
+++ b/lib/rails_i18n/common_pluralizations/one_two_other.rb
@@ -1,0 +1,26 @@
+# Used for Cornish, Inari Sami, Inuktitut, Lule Sami, Nama, Northern Sami,
+# Sami Language, Skolt Sami, Southern Sami.
+
+module RailsI18n
+  module Pluralization
+    module OneTwoOther
+      def self.rule
+        lambda do |n|
+          case n
+          when 1 then :one
+          when 2 then :two
+          else :other
+          end
+        end
+      end
+
+      def self.with_locale(locale)
+        { locale => {
+            :'i18n' => {
+              :plural => {
+                :keys => [:one, :two, :other],
+                :rule => rule }}}}
+      end
+    end
+  end
+end

--- a/lib/rails_i18n/common_pluralizations/one_upto_two_other.rb
+++ b/lib/rails_i18n/common_pluralizations/one_upto_two_other.rb
@@ -1,0 +1,21 @@
+# Used for French, Fulah, Kabyle.
+
+module RailsI18n
+  module Pluralization
+    module OneUptoTwoOther
+      def self.rule
+        lambda do |n|
+          n.is_a?(Numeric) && n >= 0 && n < 2 ? :one : :other
+        end
+      end
+
+      def self.with_locale(locale)
+        { locale => {
+            :'i18n' => {
+              :plural => {
+                :keys => [:one, :other],
+                :rule => rule }}}}
+      end
+    end
+  end
+end

--- a/lib/rails_i18n/common_pluralizations/one_with_zero_other.rb
+++ b/lib/rails_i18n/common_pluralizations/one_with_zero_other.rb
@@ -1,0 +1,25 @@
+# Used in Akan, Amharic, Bihari, Filipino, guw, Hindi, Lingala, Malagasy,
+# Northen Sotho, Tachelhit, Tagalog, Tigrinya, Walloon.
+
+module RailsI18n
+  module Pluralization
+    module OneWithZeroOther
+      def self.rule
+        lambda do |n|
+          case n
+          when 0, 1 then :one
+          else :other
+          end
+        end
+      end
+
+      def self.with_locale(locale)
+        { locale => {
+            :'i18n' => {
+              :plural => {
+                :keys => [:one, :other],
+                :rule => rule }}}}
+      end
+    end
+  end
+end

--- a/lib/rails_i18n/common_pluralizations/other.rb
+++ b/lib/rails_i18n/common_pluralizations/other.rb
@@ -1,0 +1,17 @@
+module RailsI18n
+  module Pluralization
+    module Other
+      def self.rule
+        Proc.new { :other }
+      end
+
+      def self.with_locale(locale)
+        { locale => {
+            :'i18n' => {
+              :plural => {
+                :keys => [:other],
+                :rule => rule }}}}
+      end
+    end
+  end
+end

--- a/lib/rails_i18n/common_pluralizations/romanian.rb
+++ b/lib/rails_i18n/common_pluralizations/romanian.rb
@@ -1,0 +1,31 @@
+# Used for Moldavian, Romanian.
+
+module RailsI18n
+  module Pluralization
+    module Romanian
+      FROM_1_TO_19 = (1..19).to_a.freeze
+
+      def self.rule
+        lambda do |n|
+          return :other unless n.is_a?(Numeric)
+
+          if n == 1
+            :one
+          elsif n == 0 || FROM_1_TO_19.include?(n % 100)
+            :few
+          else
+            :other
+          end
+        end
+      end
+
+      def self.with_locale(locale)
+        { locale => {
+            :'i18n' => {
+              :plural => {
+                :keys => [:one, :few, :other],
+                :rule => rule }}}}
+      end
+    end
+  end
+end

--- a/lib/rails_i18n/common_pluralizations/west_slavic.rb
+++ b/lib/rails_i18n/common_pluralizations/west_slavic.rb
@@ -1,0 +1,25 @@
+# Used for Czech, Slovak.
+
+module RailsI18n
+  module Pluralization
+    module WestSlavic
+      def self.rule
+        lambda do |n|
+          case n
+          when 1 then :one
+          when 2, 3, 4 then :few
+          else :other
+          end
+        end
+      end
+
+      def self.with_locale(locale)
+        { locale => {
+            :'i18n' => {
+              :plural => {
+                :keys => [:one, :few, :other],
+                :rule => rule }}}}
+      end
+    end
+  end
+end

--- a/lib/rails_i18n/pluralization.rb
+++ b/lib/rails_i18n/pluralization.rb
@@ -1,0 +1,143 @@
+module RailsI18n
+  module Pluralization
+    module Arabic
+      def self.rule
+        lambda do |n|
+          return :other unless n.is_a?(Numeric)
+
+          mod100 = n % 100
+
+          if n == 0
+            :zero
+          elsif n == 1
+            :one
+          elsif n == 2
+            :two
+          elsif (3..10).to_a.include?(mod100)
+            :few
+          elsif (11..99).to_a.include?(mod100)
+            :many
+          else
+            :other
+          end
+        end
+      end
+    end
+
+    module ScottishGaelic
+      def self.rule
+        lambda do |n|
+          return :other unless n.is_a?(Numeric)
+
+          floorn = n.floor
+
+          if floorn == 1 || floorn == 11
+            :one
+          elsif floorn == 2 || floorn == 12
+            :two
+          elsif (3..19).member?(floorn)
+            :few
+          else
+            :other
+          end
+        end
+      end
+    end
+
+    module UpperSorbian
+      def self.rule
+        lambda do |n|
+          return :other unless n.is_a?(Numeric)
+
+          mod100 = n % 100
+
+          case mod100
+          when 1 then :one
+          when 2 then :two
+          when 3, 4 then :few
+          else :other
+          end
+        end
+      end
+    end
+
+    module Lithuanian
+      def self.rule
+        lambda do |n|
+          return :other unless n.is_a?(Numeric)
+
+          mod10 = n % 10
+          mod100 = n % 100
+
+          if mod10 == 1 && !(11..19).to_a.include?(mod100)
+            :one
+          elsif (2..9).to_a.include?(mod10) && !(11..19).to_a.include?(mod100)
+            :few
+          else
+            :other
+          end
+        end
+      end
+    end
+
+    module Latvian
+      def self.rule
+        lambda do |n|
+          if n.is_a?(Numeric) && n % 10 == 1 && n % 100 != 11
+            :one
+          else
+            :other
+          end
+        end
+      end
+    end
+
+    module Macedonian
+      def self.rule
+        lambda do |n|
+          if n.is_a?(Numeric) && n % 10 == 1 && n != 11
+            :one
+          else
+            :other
+          end
+        end
+      end
+    end
+
+    module Polish
+      def self.rule
+        lambda do |n|
+          return :other unless n.is_a?(Numeric)
+
+          mod10 = n % 10
+          mod100 = n % 100
+
+          if n == 1
+            :one
+          elsif [2, 3, 4].include?(mod10) && ![12, 13, 14].include?(mod100)
+            :few
+          elsif [0, 1, 5, 6, 7, 8, 9].include?(mod10) || [12, 13, 14].include?(mod100)
+            :many
+          else
+            :other
+          end
+        end
+      end
+    end
+
+    module Slovenian
+      def self.rule
+        lambda do |n|
+          return :other unless n.is_a?(Numeric)
+
+          case n % 100
+          when 1 then :one
+          when 2 then :two
+          when 3, 4 then :few
+          else :other
+          end
+        end
+      end
+    end
+  end
+end

--- a/tmdb-web-translations.gemspec
+++ b/tmdb-web-translations.gemspec
@@ -21,5 +21,4 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency('i18n')
-  spec.add_dependency('rails-i18n')
 end


### PR DESCRIPTION
**What does this do?**
This removes the direct dependency on `rails-i18n` by copying over the necessary files. I've updated the script to copy pluralization rules to copy these files too so we can update if there are any changes made in future versions of the gem.