### PR TITLE
Deep alphabetize keys for locales YAML

### DIFF
--- a/locales/af-ZA.yml
+++ b/locales/af-ZA.yml
@@ -767,12 +767,18 @@ af-ZA:
   average edits per day: gemiddelde wysigings per dag
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -784,12 +790,9 @@ af-ZA:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -797,6 +800,22 @@ af-ZA:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -811,27 +830,10 @@ af-ZA:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Terug
+    ceremony:
     episode: Terug na episode
     episode_groups: Terug na episodegroepe
     episode_list: Terug na episodelys
@@ -842,8 +844,6 @@ af-ZA:
     season_list: Terug na seisoenlys
     to_tmdb: Terug na TMDB
     top: Terug boontoe
-    award:
-    ceremony:
   certifications:
     certification: Sertifisering
     descriptors:
@@ -2201,6 +2201,7 @@ af-ZA:
       wrong_length:
     movie:
       duplicate_cast: Die persoon is reeds as rolspeler toegevoeg.
+    nesting:
     tv:
       create_season_locked: Die skep van nuwe seisoen is vir hierdie reeks vergrendel.
       duplicate_created_by: Hierdie persoon is reeds as skepper toegevoeg.
@@ -2213,7 +2214,6 @@ af-ZA:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: U e-pos kon nie verstuur nie.
   failed_generic: Daar was ’n probleem
@@ -3559,6 +3559,22 @@ af-ZA:
   login_to_edit: Teken aan om te wysig
   media:
     adult: Volwasse
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Wis
@@ -3579,6 +3595,9 @@ af-ZA:
           add: Voeg rolprent toe
           no_records: Geen rolprente is toegevoeg nie.
       parts: Onderdele
+    companies:
+      companies:
+      select:
     company:
       headquarters: Hoofkwartier
       movie_page_title: Rolprente vervaardig deur %{name}
@@ -3621,6 +3640,9 @@ af-ZA:
         '7': Nog ’n klein bietjie meer…
         '8': Pomp dit op! Ons is nou naby.
         '9': Byna daar…
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -4001,28 +4023,6 @@ af-ZA:
       published_at: Uitgegee by
       restricted_regions: Beperkte streke
       tags: Etikette
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/ar-EG.yml
+++ b/locales/ar-EG.yml
@@ -785,12 +785,18 @@ ar-EG:
   average edits per day: متوسط التعديلات في اليوم
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -802,12 +808,9 @@ ar-EG:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -815,6 +818,22 @@ ar-EG:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -829,27 +848,10 @@ ar-EG:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: عودة
+    ceremony:
     episode: العودة إلى الحلقة
     episode_groups: العودة إلى مجموعة الحلقات
     episode_list: العودة إلى قائمة الحلقات
@@ -860,8 +862,6 @@ ar-EG:
     season_list: العودة إلى قائمة المواسم
     to_tmdb: العودة إلى TMDB
     top: العودة إلى الأعلى
-    award:
-    ceremony:
   certifications:
     certification: الشهادة
     descriptors: الواصفون
@@ -2144,6 +2144,7 @@ ar-EG:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2156,7 +2157,6 @@ ar-EG:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3490,6 +3490,22 @@ ar-EG:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3508,6 +3524,9 @@ ar-EG:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3550,6 +3569,9 @@ ar-EG:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3910,28 +3932,6 @@ ar-EG:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/ar-SA.yml
+++ b/locales/ar-SA.yml
@@ -789,12 +789,18 @@ ar-SA:
   average edits per day: متوسط التعديلات في اليوم
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -806,12 +812,9 @@ ar-SA:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -819,6 +822,22 @@ ar-SA:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -833,27 +852,10 @@ ar-SA:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: عوده
+    ceremony:
     episode: الرجوع إلى الحلقة
     episode_groups: الرجوع إلى مجموعات الحلقة
     episode_list: الرجوع إلى قائمة الحلقات
@@ -864,8 +866,6 @@ ar-SA:
     season_list: الرجوع إلى قائمة المواسم
     to_tmdb: الرجوع إلى TMDB
     top: العودة إلى الأعلى
-    award:
-    ceremony:
   certifications:
     certification: شهادة
     descriptors: الواصفون
@@ -2258,6 +2258,7 @@ ar-SA:
       wrong_length:
     movie:
       duplicate_cast: تمت إضافة هذا الشخص بالفعل كعضو فريق التمثيل.
+    nesting:
     tv:
       create_season_locked: تم إغلاق إنشاء مواسم جديدة لهذه السلسلة.
       duplicate_created_by: تمت إضافة هذا الشخص بالفعل كمتج.
@@ -2270,7 +2271,6 @@ ar-SA:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: فشل البريد الإلكتروني الخاص بك في الإرسال.
   failed_generic: هناك مشكلة.
@@ -3628,6 +3628,22 @@ ar-SA:
   login_to_edit: سجل دخولك لـ التعديل
   media:
     adult: بالغ
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: مسح
@@ -3652,6 +3668,9 @@ ar-SA:
           add: اضافة فلم
           no_records: لم يتم اضافة فلم.
       parts: اجزاء
+    companies:
+      companies:
+      select:
     company:
       headquarters: المقر
       movie_page_title: الأفلام المنتجة بواسطة %{name}
@@ -3694,6 +3713,9 @@ ar-SA:
         '7': نحتاج القليل فقط...
         '8': شدوا الهمة! اقتربنا الآن.
         '9': أوشكنا الوصول...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -4102,28 +4124,6 @@ ar-SA:
       published_at: نُشرفي
       restricted_regions: المناطق الممنوعة
       tags: العلامات
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/be-BY.yml
+++ b/locales/be-BY.yml
@@ -763,12 +763,18 @@ be-BY:
   average edits per day: у сярэднім правак за дзень
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -780,12 +786,9 @@ be-BY:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -793,6 +796,22 @@ be-BY:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -807,27 +826,10 @@ be-BY:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Вярнуцца
+    ceremony:
     episode: Вярнуцца да серыі
     episode_groups: Вярнуцца да групы серыі
     episode_list: Вярнуцца да спісу серыі
@@ -838,8 +840,6 @@ be-BY:
     season_list: Вярнуцца да спісу сезонаў
     to_tmdb: Вярнуцца да TMDB
     top: Вярнуцца да пачатку
-    award:
-    ceremony:
   certifications:
     certification: Сертыфікацыя
     descriptors:
@@ -2162,6 +2162,7 @@ be-BY:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2174,7 +2175,6 @@ be-BY:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3508,6 +3508,22 @@ be-BY:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3526,6 +3542,9 @@ be-BY:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3568,6 +3587,9 @@ be-BY:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3932,28 +3954,6 @@ be-BY:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/bg-BG.yml
+++ b/locales/bg-BG.yml
@@ -767,12 +767,18 @@ bg-BG:
   average edits per day: среден брой промени на ден
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -784,12 +790,9 @@ bg-BG:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -797,6 +800,22 @@ bg-BG:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -811,27 +830,10 @@ bg-BG:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Назад
+    ceremony:
     episode: Назад към епизода
     episode_groups: Назад към групите епизоди
     episode_list: Назад към списъка с епизоди
@@ -842,8 +844,6 @@ bg-BG:
     season_list: Назад към списъка със сезони
     to_tmdb: Връщане към TMDB
     top: Връщане догоре
-    award:
-    ceremony:
   certifications:
     certification: Категоризация
     descriptors:
@@ -2201,6 +2201,7 @@ bg-BG:
       wrong_length:
     movie:
       duplicate_cast: Тази личност е вече добавена като част от екипа.
+    nesting:
     tv:
       create_season_locked: Създаването на нови сезони е заключено за този сериал.
       duplicate_created_by: Тази личност вече е добавена като създател.
@@ -2213,7 +2214,6 @@ bg-BG:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: Изпращането на имейла се провали.
   failed_generic: Възникна проблем.
@@ -3552,6 +3552,22 @@ bg-BG:
   login_to_edit: Влезте, за да редактирате
   media:
     adult: За възрастни
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Изчистване
@@ -3572,6 +3588,9 @@ bg-BG:
           add: Добавяне на филм
           no_records: Не са добавени никакви филми.
       parts: Части
+    companies:
+      companies:
+      select:
     company:
       headquarters: Централа
       movie_page_title: Филми продуцирани от %{name}
@@ -3614,6 +3633,9 @@ bg-BG:
         '7': Още съвсем малко...
         '8': Давай! Близо сме.
         '9': Почти...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3994,28 +4016,6 @@ bg-BG:
       published_at: Публикувано на
       restricted_regions: Ограничени региони
       tags: Етикети
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/bn-BD.yml
+++ b/locales/bn-BD.yml
@@ -755,12 +755,18 @@ bn-BD:
   average edits per day: প্রতিদিনের গড় সম্পাদনা
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -772,12 +778,9 @@ bn-BD:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -785,6 +788,22 @@ bn-BD:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -799,27 +818,10 @@ bn-BD:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back:
+    ceremony:
     episode:
     episode_groups:
     episode_list:
@@ -830,8 +832,6 @@ bn-BD:
     season_list:
     to_tmdb:
     top:
-    award:
-    ceremony:
   certifications:
     certification: প্রত্যায়ন
     descriptors:
@@ -2158,6 +2158,7 @@ bn-BD:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2170,7 +2171,6 @@ bn-BD:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: আপনার ইমেল পাঠাতে ব্যর্থ হয়েছে।
   failed_generic: সমস্যা রয়েছে।
@@ -3507,6 +3507,22 @@ bn-BD:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3525,6 +3541,9 @@ bn-BD:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3567,6 +3586,9 @@ bn-BD:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3927,28 +3949,6 @@ bn-BD:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/bn-IN.yml
+++ b/locales/bn-IN.yml
@@ -755,12 +755,18 @@ bn-BD:
   average edits per day: প্রতিদিনের গড় সম্পাদনা
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -772,12 +778,9 @@ bn-BD:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -785,6 +788,22 @@ bn-BD:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -799,27 +818,10 @@ bn-BD:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back:
+    ceremony:
     episode:
     episode_groups:
     episode_list:
@@ -830,8 +832,6 @@ bn-BD:
     season_list:
     to_tmdb:
     top:
-    award:
-    ceremony:
   certifications:
     certification: প্রত্যায়ন
     descriptors:
@@ -2158,6 +2158,7 @@ bn-BD:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2170,7 +2171,6 @@ bn-BD:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: আপনার ইমেল পাঠাতে ব্যর্থ হয়েছে।
   failed_generic: সমস্যা রয়েছে।
@@ -3507,6 +3507,22 @@ bn-BD:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3525,6 +3541,9 @@ bn-BD:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3567,6 +3586,9 @@ bn-BD:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3927,28 +3949,6 @@ bn-BD:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/ca-AD.yml
+++ b/locales/ca-AD.yml
@@ -767,12 +767,18 @@ ca-AD:
   average edits per day: mitjana d'edicions per dia
   awards:
     add_nomination: Afegeix nominació
+    admin:
+      delete:
     air_date:
       future: S'emet el %{date}
       past: Emès el %{date}
     alternative_names: Noms alternatius
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: Categories
       add_category:
       categories:
       category:
@@ -784,12 +790,9 @@ ca-AD:
       locked:
       media_type:
       name:
+      title: Categories
     category_empty: Categoria deserta.
     ceremonies:
-      number: Número
-      release_date_max: Data d'emissió màx
-      release_date_min: Data d'emissió min
-      title: Cerimònies
       add_ceremony:
       ceremonies:
       ceremony:
@@ -797,9 +800,23 @@ ca-AD:
       limits:
       location:
       locked:
+      number: Número
+      release_date_max: Data d'emissió màx
+      release_date_min: Data d'emissió min
+      title: Cerimònies
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      one: 1 nominació
-      other: "%{count} nominacions"
       add_nomination:
       locked:
       movie:
@@ -807,6 +824,8 @@ ca-AD:
       number:
         one:
         other:
+      one: 1 nominació
+      other: "%{count} nominacions"
       title:
     nominee: Nominat
     show_info:
@@ -823,27 +842,10 @@ ca-AD:
     wins:
       one: 1 guardó
       other: "%{count} guardons"
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Enrere
+    ceremony:
     episode: Torna a l'episodi
     episode_groups: Torna al grup d'episodis
     episode_list: Torna a la llista d'episodis
@@ -854,8 +856,6 @@ ca-AD:
     season_list: Torna a la llista de temporades
     to_tmdb: Torna a TMDB
     top: Torna a dalt
-    award:
-    ceremony:
   certifications:
     certification: Classificació per edats
     descriptors: Descriptors
@@ -2239,6 +2239,7 @@ ca-AD:
         other: és l'allargada errònia (hauria de ser %{count} caràcters)
     movie:
       duplicate_cast: Aquest artista ja està afegit com a membre de repartiment.
+    nesting:
     tv:
       create_season_locked: La creació de noves temporades ha estat blocada per aquesta sèrie.
       duplicate_created_by: Aquest artista ja ha estat afegit com a creador.
@@ -2251,7 +2252,6 @@ ca-AD:
       duplicate_season_episode_crew_member: Aquesta persona ja s'ha afegit com a %{job_name} a un episodi d'aquesta sessió. Els crèdits de l'equip tècnic han de ser afegits a una temporada o episodi, però no a tots dos.
       missing_credit: El crèdit que intentàveu obrir no existeix.
       missing_person: No s'ha pogut trobar la persona que heu introduït.
-    nesting:
     wrong_count:
   failed_email: No s'ha pogut enviar el vostre correu electrònic.
   failed_generic: Hi ha hagut un problema.
@@ -3597,6 +3597,22 @@ ca-AD:
   login_to_edit: Inicieu la sessió per a editar
   media:
     adult: Adult
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Neteja
@@ -3617,6 +3633,9 @@ ca-AD:
           add: Afegiu-hi una pel·lícula
           no_records: No s'hi han afegit pel·lícules.
       parts: Parts
+    companies:
+      companies:
+      select:
     company:
       headquarters: Seu
       movie_page_title: Pel·lícules produïdes per %{name}
@@ -3659,6 +3678,9 @@ ca-AD:
         '7': Només una miqueta més...
         '8': Fum-li fort, que ja hi som!
         '9': Ja gairebé hi som...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing: Bloca els títols existents
@@ -4039,28 +4061,6 @@ ca-AD:
       published_at: Publicat a
       restricted_regions: Regions restringides
       tags: Etiquetes
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/ca-ES.yml
+++ b/locales/ca-ES.yml
@@ -767,12 +767,18 @@ ca-ES:
   average edits per day: mitjana d'edicions per dia
   awards:
     add_nomination: Afegeix nominació
+    admin:
+      delete:
     air_date:
       future: S'emet el %{date}
       past: Emès el %{date}
     alternative_names: Noms alternatius
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: Categories
       add_category:
       categories:
       category:
@@ -784,12 +790,9 @@ ca-ES:
       locked:
       media_type:
       name:
+      title: Categories
     category_empty: Categoria deserta.
     ceremonies:
-      number: Número
-      release_date_max: Data d'emissió màx
-      release_date_min: Data d'emissió min
-      title: Cerimònies
       add_ceremony:
       ceremonies:
       ceremony:
@@ -797,9 +800,23 @@ ca-ES:
       limits:
       location:
       locked:
+      number: Número
+      release_date_max: Data d'emissió màx
+      release_date_min: Data d'emissió min
+      title: Cerimònies
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      one: 1 nominació
-      other: "%{count} nominacions"
       add_nomination:
       locked:
       movie:
@@ -807,6 +824,8 @@ ca-ES:
       number:
         one:
         other:
+      one: 1 nominació
+      other: "%{count} nominacions"
       title:
     nominee: Nominat
     show_info:
@@ -823,27 +842,10 @@ ca-ES:
     wins:
       one: 1 guardó
       other: "%{count} guardons"
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Torna
+    ceremony:
     episode: Torna a l'episodi
     episode_groups: Torna al grup d'episodis
     episode_list: Torna a la llista d'episodis
@@ -854,8 +856,6 @@ ca-ES:
     season_list: Torna a la llista de temporades
     to_tmdb: Torna a TMDB
     top: Torna a dalt
-    award:
-    ceremony:
   certifications:
     certification: Classificació per edats
     descriptors: Descriptors
@@ -2239,6 +2239,7 @@ ca-ES:
         other: és l'allargada errònia (hauria de ser %{count} caràcters)
     movie:
       duplicate_cast: Aquest artista ja està afegit com a membre de repartiment.
+    nesting:
     tv:
       create_season_locked: La creació de noves temporades ha estat blocada per aquesta sèrie.
       duplicate_created_by: Aquest artista ja ha estat afegit com a creador.
@@ -2251,7 +2252,6 @@ ca-ES:
       duplicate_season_episode_crew_member: Aquesta persona ja s'ha afegit com a %{job_name} a un episodi d'aquesta sessió. Els crèdits de l'equip tècnic han de ser afegits a una temporada o episodi, però no a tots dos.
       missing_credit: El crèdit que intentàveu obrir no existeix.
       missing_person: No s'ha pogut trobar la persona que heu introduït.
-    nesting:
     wrong_count:
   failed_email: No s'ha pogut enviar el vostre correu electrònic.
   failed_generic: Hi ha hagut un problema.
@@ -3597,6 +3597,22 @@ ca-ES:
   login_to_edit: Inicieu la sessió per a editar
   media:
     adult: Adult
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Neteja
@@ -3617,6 +3633,9 @@ ca-ES:
           add: Afegiu-hi una pel·lícula
           no_records: No s'hi han afegit pel·lícules.
       parts: Parts
+    companies:
+      companies:
+      select:
     company:
       headquarters: Seu
       movie_page_title: Pel·lícules produïdes per %{name}
@@ -3659,6 +3678,9 @@ ca-ES:
         '7': Només una miqueta més...
         '8': Fum-li fort, que ja hi som!
         '9': Ja gairebé hi som...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing: Bloca els títols existents
@@ -4039,28 +4061,6 @@ ca-ES:
       published_at: Publicat a
       restricted_regions: Regions restingides
       tags: Etiquetes
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/cs-CZ.yml
+++ b/locales/cs-CZ.yml
@@ -767,12 +767,18 @@ cs-CZ:
   average edits per day: úprav v průměru za den
   awards:
     add_nomination: Přidat nominaci
+    admin:
+      delete:
     air_date:
       future: Bude se vysílat %{date}
       past: Vysílalo se %{date}
     alternative_names: Alternativní jména
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: Kategorie
       add_category:
       categories:
       category:
@@ -784,12 +790,9 @@ cs-CZ:
       locked:
       media_type:
       name:
+      title: Kategorie
     category_empty: V této kategorii není žádná nominace.
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title: Slavnostní předávání
       add_ceremony:
       ceremonies:
       ceremony:
@@ -797,18 +800,34 @@ cs-CZ:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title: Slavnostní předávání
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      few: "%{count} nominace"
-      one: 1 nominace
-      other: "%{count} nominací"
       add_nomination:
+      few: "%{count} nominace"
       locked:
       movie:
       nomination:
       number:
-        one:
         few:
+        one:
         other:
+      one: 1 nominace
+      other: "%{count} nominací"
       title:
     nominee: Nominace
     show_info:
@@ -826,27 +845,10 @@ cs-CZ:
       few: ''
       one: 1 vítězství
       other: "%{count} vítězství"
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Zpět
+    ceremony:
     episode: Zpět na epizodu
     episode_groups: Zpět na skupiny epizod
     episode_list: Zpět na seznam epizod
@@ -857,8 +859,6 @@ cs-CZ:
     season_list: Zpět na seznam sezón
     to_tmdb: Zpět na TMDB
     top: Zpět nahoru
-    award:
-    ceremony:
   certifications:
     certification: Certifikace
     descriptors:
@@ -2228,6 +2228,7 @@ cs-CZ:
       wrong_length:
     movie:
       duplicate_cast: Tato osoba již je přidána jako člen obsazení.
+    nesting:
     tv:
       create_season_locked: Vytváření nových sezón bylo pro tento seriál uzamčeno.
       duplicate_created_by: Tato osoba již je přidána jako tvůrce.
@@ -2240,7 +2241,6 @@ cs-CZ:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: Váš e-mail se nepodařilo odeslat.
   failed_generic: Došlo k problému.
@@ -3584,6 +3584,22 @@ cs-CZ:
   login_to_edit: Pro úpravu se přihlaste
   media:
     adult: Pro dospělé
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Zrušit filtr
@@ -3605,6 +3621,9 @@ cs-CZ:
           add: Přidat film
           no_records: Nebyly přidány žádné filmy.
       parts: Díly
+    companies:
+      companies:
+      select:
     company:
       headquarters: Sídlo
       movie_page_title: Filmy od společnosti %{name}
@@ -3647,6 +3666,9 @@ cs-CZ:
         '7': Ještě trochu víc...
         '8': Do toho! Jsme už blízko.
         '9': Už to bude...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing: Uzamknout názvy
@@ -4034,28 +4056,6 @@ cs-CZ:
       published_at: Publikováno
       restricted_regions:
       tags: Štítky
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/da-DK.yml
+++ b/locales/da-DK.yml
@@ -767,12 +767,18 @@ da-DK:
   average edits per day: gennemsnitlige redigeringer per dag
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -784,12 +790,9 @@ da-DK:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -797,6 +800,22 @@ da-DK:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -811,27 +830,10 @@ da-DK:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Tilbage
+    ceremony:
     episode: Tilbage til episode
     episode_groups: Tilbage til episodegrupper
     episode_list: Tilbage til episodeliste
@@ -842,8 +844,6 @@ da-DK:
     season_list: Tilbage til sæsonliste
     to_tmdb: Tilbage til TMDB
     top: Tilbage til toppen
-    award:
-    ceremony:
   certifications:
     certification: Alderscertificering
     descriptors: Deskriptorer
@@ -2201,6 +2201,7 @@ da-DK:
       wrong_length:
     movie:
       duplicate_cast: Denne person er allerede tilføjet som skuespiller
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by: Denne person er allerede tilføjet som skaber
@@ -2213,7 +2214,6 @@ da-DK:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: Din e-mail mislykkedes at sende.
   failed_generic: Der opstod et problem
@@ -3552,6 +3552,22 @@ da-DK:
   login_to_edit: Log ind for at redigere
   media:
     adult: Voksen
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Ryd
@@ -3570,6 +3586,9 @@ da-DK:
           add: Tilføj film
           no_records: Ingen film er blevet tilføjet.
       parts: Dele
+    companies:
+      companies:
+      select:
     company:
       headquarters: Hovedkvarter
       movie_page_title: Film produceret af %{name}
@@ -3612,6 +3631,9 @@ da-DK:
         '7': Bare en lille smule mere...
         '8': Pump det! Vi er så tæt på nu.
         '9': Næsten...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3976,28 +3998,6 @@ da-DK:
       published_at:
       restricted_regions: Begrænsede regioner
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/de-DE.yml
+++ b/locales/de-DE.yml
@@ -765,12 +765,18 @@ de-DE:
   average edits per day: durchschnittliche Beiträge pro Tag
   awards:
     add_nomination: Nominierung hinzufügen
+    admin:
+      delete:
     air_date:
       future: Ausstrahlung am %{date}
       past: Ausgestrahlt am %{date}
     alternative_names: Alternativnamen
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: Kategorien
       add_category:
       categories:
       category:
@@ -782,12 +788,9 @@ de-DE:
       locked:
       media_type:
       name:
+      title: Kategorien
     category_empty: Keine Nominierungen für diese Kategorie.
     ceremonies:
-      number: Nummer
-      release_date_max: Maximales Veröffentlichungsdatum
-      release_date_min: Minimales Veröffentlichungsdatum
-      title: Zeremonien
       add_ceremony:
       ceremonies:
       ceremony:
@@ -795,9 +798,23 @@ de-DE:
       limits:
       location:
       locked:
+      number: Nummer
+      release_date_max: Maximales Veröffentlichungsdatum
+      release_date_min: Minimales Veröffentlichungsdatum
+      title: Zeremonien
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      one: 1 Nominierung
-      other: "%{count} Nominierungen"
       add_nomination:
       locked:
       movie:
@@ -805,6 +822,8 @@ de-DE:
       number:
         one:
         other:
+      one: 1 Nominierung
+      other: "%{count} Nominierungen"
       title:
     nominee: Nominiert
     show_info:
@@ -821,27 +840,10 @@ de-DE:
     wins:
       one: 1 Gewinn
       other: "%{count} Gewinne"
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Zurück
+    ceremony:
     episode: Zurück zur Folge
     episode_groups: Zurück zu den Folgengruppen
     episode_list: Zurück zur Folgenliste
@@ -852,8 +854,6 @@ de-DE:
     season_list: Zurück zur Staffelliste
     to_tmdb: Zurück zur TMDB
     top: Zurück nach oben
-    award:
-    ceremony:
   certifications:
     certification: Altersfreigabe
     descriptors: Deskriptoren
@@ -2211,6 +2211,7 @@ de-DE:
       wrong_length:
     movie:
       duplicate_cast: Diese Person ist bereits Teil der Besetzung.
+    nesting:
     tv:
       create_season_locked: Das Hinzufügen neuer Staffeln wurde für diese Serie gesperrt.
       duplicate_created_by: Die Person wurde bereits als Urheber hinzugefügt.
@@ -2223,7 +2224,6 @@ de-DE:
       duplicate_season_episode_crew_member: Diese Person wurde schon als %{job_name} einer Folge dieser Staffel hinzugefügt. Creweinträge dürfen nur einer Staffel oder einer Folge hinzugefügt werden, aber nicht beiden.
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: Deine E-Mail konnte nicht gesendet werden.
   failed_generic: Es trat ein Fehler auf.
@@ -3570,6 +3570,22 @@ de-DE:
   login_to_edit: Anmelden, um zu bearbeiten
   media:
     adult: Erwachsene
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Zurücksetzen
@@ -3590,6 +3606,9 @@ de-DE:
           add: Film hinzufügen
           no_records: Es wurden keine Filme hinzugefügt.
       parts: Teile
+    companies:
+      companies:
+      select:
     company:
       headquarters: Hauptsitz
       movie_page_title: Filme produziert von %{name}
@@ -3632,6 +3651,9 @@ de-DE:
         '7': Noch ein bisschen mehr …
         '8': Durchhalten! Wir sind fast fertig.
         '9': Fast geschafft …
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing: Vorhanden Titel sperren
@@ -4012,28 +4034,6 @@ de-DE:
       published_at: Veröffentlicht auf
       restricted_regions: Länderrestriktion
       tags: Schlagwörter
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/el-GR.yml
+++ b/locales/el-GR.yml
@@ -769,12 +769,18 @@ el-GR:
   average edits per day: μέσος όρος επεξεργασιών ανά ημέρα
   awards:
     add_nomination: Προσθήκη υποψηφιότητας
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -786,12 +792,9 @@ el-GR:
       locked:
       media_type:
       name:
+      title:
     category_empty: Δεν υπάρχουν υποψηφιότητες για αυτήν την κατηγορία.
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -799,9 +802,23 @@ el-GR:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      one: 1 Υποψηφιότητα
-      other: "%{count} Υποψηφιότητες"
       add_nomination:
       locked:
       movie:
@@ -809,6 +826,8 @@ el-GR:
       number:
         one:
         other:
+      one: 1 Υποψηφιότητα
+      other: "%{count} Υποψηφιότητες"
       title:
     nominee: Υποψήφιος
     show_info:
@@ -825,27 +844,10 @@ el-GR:
     wins:
       one: 1 Νίκη
       other: "%{count} Νίκες"
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Πίσω
+    ceremony:
     episode: Επιστροφή στο επεισόδιο
     episode_groups: Επιστροφή στις ομάδες επεισοδίων
     episode_list: Επιστροφή στη λίστα επεισοδίων
@@ -856,8 +858,6 @@ el-GR:
     season_list: Επιστροφή στη λίστα κύκλων
     to_tmdb: Επιστροφή στο TMDB
     top: Επιστροφή στην κορυφή
-    award:
-    ceremony:
   certifications:
     certification: Καταλληλότητα
     descriptors: Περιγραφείς
@@ -2226,6 +2226,7 @@ el-GR:
       wrong_length:
     movie:
       duplicate_cast: Αυτό το άτομο έχει ήδη προστεθεί ως ηθοποιός.
+    nesting:
     tv:
       create_season_locked: Η δημιουργία νέων κύκλων έχει κλειδωθεί για αυτή τη σειρά.
       duplicate_created_by: Αυτό το άτομο έχει ήδη προστεθεί ως δημιουργός.
@@ -2238,7 +2239,6 @@ el-GR:
       duplicate_season_episode_crew_member: Αυτό το άτομο έχει ήδη προστεθεί ως %{job_name} σε ένα επεισόδιο αυτής της σεζόν. Οι πιστώσεις πληρώματος πρέπει να προστεθούν είτε σε μια σεζόν είτε σε ένα επεισόδιο και όχι και στα δύο.
       missing_credit: Η πίστωση που προσπαθούσατε να επεξεργαστείτε δεν υπάρχει.
       missing_person: Το άτομο που καταχωρήσατε δεν βρέθηκε.
-    nesting:
     wrong_count:
   failed_email: Το email σας απέτυχε να στείλει.
   failed_generic: Υπήρξε κάποιο πρόβλημα.
@@ -3585,6 +3585,22 @@ el-GR:
   login_to_edit: Συνδεθείτε για να επεξεργαστείτε
   media:
     adult: Ενήλικες
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Εκκαθάριση
@@ -3605,6 +3621,9 @@ el-GR:
           add: Προσθήκη Ταινίας
           no_records: Δεν έχουν προστεθεί ταινίες.
       parts: Μέρη
+    companies:
+      companies:
+      select:
     company:
       headquarters: Εγκαταστάσεις
       movie_page_title: 'Ταινίες που έχουν παραχθεί από τον/την %{name} '
@@ -3647,6 +3666,9 @@ el-GR:
         '7': Λίγο ακόμα...
         '8': Ανεβάστε ρυθμούς! Είμαστε κοντά τώρα.
         '9': Σχεδόν φτάσαμε...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing: Κλείδωμα Υπαρχόντων Τίτλων
@@ -4027,28 +4049,6 @@ el-GR:
       published_at: Δημοσιεύτηκε στο
       restricted_regions: Περιοχές με περιορισμό
       tags: Ετικέτες
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/en-AU.yml
+++ b/locales/en-AU.yml
@@ -759,12 +759,18 @@ en-AU:
   average edits per day:
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -776,12 +782,9 @@ en-AU:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -789,6 +792,22 @@ en-AU:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -803,27 +822,10 @@ en-AU:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back:
+    ceremony:
     episode:
     episode_groups:
     episode_list:
@@ -834,8 +836,6 @@ en-AU:
     season_list:
     to_tmdb:
     top:
-    award:
-    ceremony:
   certifications:
     certification:
     descriptors:
@@ -2184,6 +2184,7 @@ en-AU:
         other: is the wrong length (should be %{count} characters)
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2196,7 +2197,6 @@ en-AU:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3537,6 +3537,22 @@ en-AU:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3557,6 +3573,9 @@ en-AU:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3599,6 +3618,9 @@ en-AU:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3969,28 +3991,6 @@ en-AU:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/en-CA.yml
+++ b/locales/en-CA.yml
@@ -759,12 +759,18 @@ en-CA:
   average edits per day:
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -776,12 +782,9 @@ en-CA:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -789,6 +792,22 @@ en-CA:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -803,27 +822,10 @@ en-CA:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back:
+    ceremony:
     episode:
     episode_groups:
     episode_list:
@@ -834,8 +836,6 @@ en-CA:
     season_list:
     to_tmdb:
     top:
-    award:
-    ceremony:
   certifications:
     certification:
     descriptors:
@@ -2184,6 +2184,7 @@ en-CA:
         other: is the wrong length (should be %{count} characters)
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2196,7 +2197,6 @@ en-CA:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3537,6 +3537,22 @@ en-CA:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3557,6 +3573,9 @@ en-CA:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3599,6 +3618,9 @@ en-CA:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3969,28 +3991,6 @@ en-CA:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/en-GB.yml
+++ b/locales/en-GB.yml
@@ -763,12 +763,18 @@ en-GB:
   average edits per day:
   awards:
     add_nomination: Add nomination
+    admin:
+      delete:
     air_date:
       future: Airs %{date}
       past: Aired %{date}
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -780,12 +786,9 @@ en-GB:
       locked:
       media_type:
       name:
+      title:
     category_empty: No nominations for this category.
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -793,9 +796,23 @@ en-GB:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      one: 1 Nomination
-      other: "%{count} Nominations"
       add_nomination:
       locked:
       movie:
@@ -803,6 +820,8 @@ en-GB:
       number:
         one:
         other:
+      one: 1 Nomination
+      other: "%{count} Nominations"
       title:
     nominee: Nominee
     show_info:
@@ -819,27 +838,10 @@ en-GB:
     wins:
       one: 1 Win
       other: "%{count} Wins"
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back:
+    ceremony:
     episode:
     episode_groups:
     episode_list:
@@ -850,8 +852,6 @@ en-GB:
     season_list:
     to_tmdb:
     top:
-    award:
-    ceremony:
   certifications:
     certification: Classification
     descriptors:
@@ -2200,6 +2200,7 @@ en-GB:
         other: is the wrong length (should be %{count} characters)
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2212,7 +2213,6 @@ en-GB:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3553,6 +3553,22 @@ en-GB:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3573,6 +3589,9 @@ en-GB:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3615,6 +3634,9 @@ en-GB:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3985,28 +4007,6 @@ en-GB:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -765,12 +765,18 @@ en-US:
   average edits per day: average edits per day
   awards:
     add_nomination: Add nomination
+    admin:
+      delete: Delete Award
     air_date:
       future: Airs %{date}
       past: Aired %{date}
     alternative_names: Alternative Names
+    award: Award
+    broadcast_episode: Broadcast Episode
+    broadcast_episode_tooltip: Linking to a TV episode will display production information.
+    broadcast_series: Broadcast Series
+    broadcast_series_tooltip: Linking a TV series allows displaying production information for each ceremony.
     categories:
-      title: Categories
       add_category: Add Category
       categories: Categories
       category: Category
@@ -782,12 +788,9 @@ en-US:
       locked: Adding new categories has been disabled and locked by a moderator.
       media_type: Media Type
       name: Name
+      title: Categories
     category_empty: No nominations for this category.
     ceremonies:
-      number: Number
-      release_date_max: Release Date Max
-      release_date_min: Release Date Min
-      title: Ceremonies
       add_ceremony: Add ceremony
       ceremonies: Ceremonies
       ceremony: Ceremony
@@ -795,9 +798,23 @@ en-US:
       limits: Limits
       location: Location
       locked: Adding new ceremonies has been disabled and locked by a moderator.
+      number: Number
+      release_date_max: Release Date Max
+      release_date_min: Release Date Min
+      title: Ceremonies
+    field:
+      homepage: Homepage
+      name: Name
+      overview: Overview
+    new_award:
+      award_details: Award Details
+      click_next: This 3 step wizard will walk you through the creation process. To get started, click next.
+      getting_started: Getting Started
+      header_1: New Award
+      header_2: Add a New Award
+      note: Adding a new award on TMDB is simple and easy. If you have any questions about how our editing system works make sure to read through our <a href="%{bible_href}">contribition bible</a> or stop by the <a href="%{talk_href}">forums</a>.
+      verify: Verify and Save
     nominations:
-      one: 1 Nomination
-      other: "%{count} Nominations"
       add_nomination: Add Nomination
       locked: Adding new nominations has been disabled and locked by a moderator.
       movie: Movie
@@ -805,6 +822,8 @@ en-US:
       number:
         one:
         other:
+      one: 1 Nomination
+      other: "%{count} Nominations"
       title: Nominations
     nominee: Nominee
     show_info:
@@ -821,27 +840,10 @@ en-US:
     wins:
       one: 1 Win
       other: "%{count} Wins"
-    award: Award
-    broadcast_episode: Broadcast Episode
-    broadcast_episode_tooltip: Linking to a TV episode will display production information.
-    broadcast_series: Broadcast Series
-    broadcast_series_tooltip: Linking a TV series allows displaying production information for each ceremony.
-    field:
-      homepage: Homepage
-      name: Name
-      overview: Overview
-    new_award:
-      award_details: Award Details
-      click_next: This 3 step wizard will walk you through the creation process. To get started, click next.
-      getting_started: Getting Started
-      header_1: New Award
-      header_2: Add a New Award
-      note: Adding a new award on TMDB is simple and easy. If you have any questions about how our editing system works make sure to read through our <a href="%{bible_href}">contribition bible</a> or stop by the <a href="%{talk_href}">forums</a>.
-      verify: Verify and Save
-    admin:
-      delete: Delete Award
   back_options:
+    award: Back to award
     back: Back
+    ceremony: Back to ceremony
     episode: Back to episode
     episode_groups: Back to episode groups
     episode_list: Back to episode list
@@ -852,8 +854,6 @@ en-US:
     season_list: Back to season list
     to_tmdb: Back to TMDB
     top: Back to top
-    award: Back to award
-    ceremony: Back to ceremony
   certifications:
     certification: Certification
     descriptors: Descriptors
@@ -2236,6 +2236,7 @@ en-US:
         other: is the wrong length (should be %{count} characters)
     movie:
       duplicate_cast: This person is already added as a cast member.
+    nesting: has invalid nesting
     tv:
       create_season_locked: The creation of new seasons has been locked for this series.
       duplicate_created_by: This person is already added as a creator.
@@ -2248,7 +2249,6 @@ en-US:
       duplicate_season_episode_crew_member: This person is already added as a %{job_name} to an episode of this season. Crew credits need to be added to either a season, or an episode, and not both.
       missing_credit: The credit you were trying to edit doesn't exist.
       missing_person: The person you entered could not be found.
-    nesting: has invalid nesting
     wrong_count: is the wrong length (must have %{count} items)
   failed_email: Your email failed to send.
   failed_generic: There was a problem.
@@ -3595,6 +3595,22 @@ en-US:
   login_to_edit: Login to edit
   media:
     adult: Adult
+    alternative_names:
+      add_name: Add Name
+      alternative_names: Alternative Names
+      name: Name
+      no_records: No alternative names have been added.
+    award:
+      edit:
+        adult:
+          adult_award: Adult Award
+        title_logos: Title Logos
+      header:
+        latest_ceremony: Check out the latest ceremony
+        upcoming_ceremony: Check out the upcoming ceremony
+    cast_credits:
+      cast_credits: Cast Credits
+      select: Select cast credits...
     changes:
       filters:
         clear: Clear
@@ -3615,6 +3631,9 @@ en-US:
           add: Add Movie
           no_records: No movies have been added.
       parts: Parts
+    companies:
+      companies: Companies
+      select: Select companies...
     company:
       headquarters: Headquarters
       movie_page_title: Movies produced by %{name}
@@ -3657,6 +3676,9 @@ en-US:
         '7': Just a little bit more...
         '8': Pump it up! We're close now.
         '9': Almost there...
+    crew_credits:
+      crew_credits: Crew Credits
+      select: Select crew credits...
     edit:
       alternative_title:
         lock_existing: Lock Existing Titles
@@ -4037,28 +4059,6 @@ en-US:
       published_at: Published At
       restricted_regions: Restricted Regions
       tags: Tags
-    alternative_names:
-      add_name: Add Name
-      alternative_names: Alternative Names
-      name: Name
-      no_records: No alternative names have been added.
-    award:
-      edit:
-        adult:
-          adult_award: Adult Award
-        title_logos: Title Logos
-      header:
-        latest_ceremony: Check out the latest ceremony
-        upcoming_ceremony: Check out the upcoming ceremony
-    cast_credits:
-      cast_credits: Cast Credits
-      select: Select cast credits...
-    companies:
-      companies: Companies
-      select: Select companies...
-    crew_credits:
-      crew_credits: Crew Credits
-      select: Select crew credits...
     wizard:
       award_details: Award Details
       getting_started: Getting Started

--- a/locales/eo-EO.yml
+++ b/locales/eo-EO.yml
@@ -763,12 +763,18 @@ eo:
   average edits per day:
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -780,12 +786,9 @@ eo:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -793,6 +796,22 @@ eo:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -807,27 +826,10 @@ eo:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Reen
+    ceremony:
     episode: Reen al epizodo
     episode_groups: Reen al epizodaj grupoj
     episode_list: Reen al listo de epizodoj
@@ -838,8 +840,6 @@ eo:
     season_list: Reen al listo de sezonoj
     to_tmdb: Reen al TMDB
     top: Reen al supro
-    award:
-    ceremony:
   certifications:
     certification:
     descriptors:
@@ -2166,6 +2166,7 @@ eo:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2178,7 +2179,6 @@ eo:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic: Estis problemo.
@@ -3516,6 +3516,22 @@ eo:
   login_to_edit: Ensaluti por redakti
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3536,6 +3552,9 @@ eo:
           add: Aldoni filmon
           no_records: Neniu filmo estis aldonita.
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3578,6 +3597,9 @@ eo:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3950,28 +3972,6 @@ eo:
       published_at:
       restricted_regions:
       tags: Etikedoj
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/es-AR.yml
+++ b/locales/es-AR.yml
@@ -759,12 +759,18 @@ es-AR:
   average edits per day:
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -776,12 +782,9 @@ es-AR:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -789,6 +792,22 @@ es-AR:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -803,27 +822,10 @@ es-AR:
     title: Premios
     winner: Ganador
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back:
+    ceremony:
     episode:
     episode_groups:
     episode_list:
@@ -834,8 +836,6 @@ es-AR:
     season_list:
     to_tmdb:
     top:
-    award:
-    ceremony:
   certifications:
     certification: Certificación
     descriptors:
@@ -2160,6 +2160,7 @@ es-AR:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2172,7 +2173,6 @@ es-AR:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3506,6 +3506,22 @@ es-AR:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3524,6 +3540,9 @@ es-AR:
           add: Agregar película
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3566,6 +3585,9 @@ es-AR:
         '7':
         '8':
         '9': Falta poco...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3928,28 +3950,6 @@ es-AR:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/es-CL.yml
+++ b/locales/es-CL.yml
@@ -765,12 +765,18 @@ es-CL:
   average edits per day: cantidad promedio de modificaciones diarias
   awards:
     add_nomination: Agregar nominación
+    admin:
+      delete:
     air_date:
       future: Se estrena el %{date}
       past: Se estrenó el %{date}
     alternative_names: Nombres alternativos
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: Categorías
       add_category:
       categories:
       category:
@@ -782,12 +788,9 @@ es-CL:
       locked:
       media_type:
       name:
+      title: Categorías
     category_empty: No existen nominaciones para esta categoría.
     ceremonies:
-      number: Número
-      release_date_max: Fecha límite de lanzamiento
-      release_date_min: Fecha mínima de lanzamiento
-      title: Ceremonias
       add_ceremony:
       ceremonies:
       ceremony:
@@ -795,9 +798,23 @@ es-CL:
       limits:
       location:
       locked:
+      number: Número
+      release_date_max: Fecha límite de lanzamiento
+      release_date_min: Fecha mínima de lanzamiento
+      title: Ceremonias
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      one: 1 nominación
-      other: "%{count} nominaciones"
       add_nomination:
       locked:
       movie:
@@ -805,6 +822,8 @@ es-CL:
       number:
         one:
         other:
+      one: 1 nominación
+      other: "%{count} nominaciones"
       title:
     nominee: Nominado
     show_info:
@@ -821,27 +840,10 @@ es-CL:
     wins:
       one: 1 premio
       other: "%{count} premios"
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Regresar
+    ceremony:
     episode: Regresar al episodio
     episode_groups: Regresar a los grupos de episodios
     episode_list: Regresar al listado de episodios
@@ -852,8 +854,6 @@ es-CL:
     season_list: Regresar al listado de temporadas
     to_tmdb: Regresar a TMDB
     top: Volver al principio
-    award:
-    ceremony:
   certifications:
     certification: Clasificación
     descriptors: Descriptores
@@ -2141,6 +2141,7 @@ es-CL:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2153,7 +2154,6 @@ es-CL:
       duplicate_season_episode_crew_member:
       missing_credit: El crédito que quisiste modificar no existe.
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3493,6 +3493,22 @@ es-CL:
   login_to_edit: Accede para modificar
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3511,6 +3527,9 @@ es-CL:
           add: Agregar película
           no_records: No se agregó ninguna película.
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters: Sede
       movie_page_title: Películas producidas por %{name}
@@ -3553,6 +3572,9 @@ es-CL:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing: Bloquear títulos actuales
@@ -3921,28 +3943,6 @@ es-CL:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/es-ES.yml
+++ b/locales/es-ES.yml
@@ -767,12 +767,18 @@ es-ES:
   average edits per day: promedio de ediciones por día
   awards:
     add_nomination: Añadir nominación
+    admin:
+      delete:
     air_date:
       future: Se emite %{date}
       past: Emitido %{date}
     alternative_names: Nombres alternativos
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: Categorías
       add_category:
       categories:
       category:
@@ -784,12 +790,9 @@ es-ES:
       locked:
       media_type:
       name:
+      title: Categorías
     category_empty: No hay nominaciones en esta categoría.
     ceremonies:
-      number: 'Número '
-      release_date_max: Fecha máxima de estreno
-      release_date_min: Fecha mínima de estreno
-      title: Ceremonias
       add_ceremony:
       ceremonies:
       ceremony:
@@ -797,9 +800,23 @@ es-ES:
       limits:
       location:
       locked:
+      number: 'Número '
+      release_date_max: Fecha máxima de estreno
+      release_date_min: Fecha mínima de estreno
+      title: Ceremonias
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      one: 1 nominación
-      other: "%{count} nominaciones"
       add_nomination:
       locked:
       movie:
@@ -807,6 +824,8 @@ es-ES:
       number:
         one:
         other:
+      one: 1 nominación
+      other: "%{count} nominaciones"
       title:
     nominee: Nominado
     show_info:
@@ -823,27 +842,10 @@ es-ES:
     wins:
       one: 1 victoria
       other: "%{count} victorias"
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Volver
+    ceremony:
     episode: Volver al episodio
     episode_groups: Volver al grupo de episodios
     episode_list: Volver a la lista de episodios
@@ -854,8 +856,6 @@ es-ES:
     season_list: Volver a lista de temporadas
     to_tmdb: Volver a TMDB
     top: Volver arriba
-    award:
-    ceremony:
   certifications:
     certification: Certificación
     descriptors: Descriptores
@@ -2240,6 +2240,7 @@ es-ES:
         other: La longitud es incorrecta (deberían ser %{count} caracteres)
     movie:
       duplicate_cast: Esta persona ya está añadida como miembro del reparto.
+    nesting:
     tv:
       create_season_locked: La creación de nuevas temporadas ha sido bloqueada en este programa de televisión .
       duplicate_created_by: Esta persona ya está añadida como creador.
@@ -2252,7 +2253,6 @@ es-ES:
       duplicate_season_episode_crew_member: Esta persona ya está agregada como %{job_name} a un episodio de esta temporada. Los créditos del equipo deben agregarse a una temporada o a un episodio, y no a ambos.
       missing_credit: Los créditos que intentabas editar, no existen.
       missing_person: No se pudo encontrar la persona que ingresó.
-    nesting:
     wrong_count:
   failed_email: No se ha podido enviar tu correo electrónico.
   failed_generic: Ha habido un problema.
@@ -3599,6 +3599,22 @@ es-ES:
   login_to_edit: Iniciar sesión para editar
   media:
     adult: Adulto
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Limpiar
@@ -3619,6 +3635,9 @@ es-ES:
           add: Añadir película
           no_records: No se han añadido películas.
       parts: Partes
+    companies:
+      companies:
+      select:
     company:
       headquarters: Sede
       movie_page_title: Películas producidas por %{name}
@@ -3661,6 +3680,9 @@ es-ES:
         '7': Solo un poco más...
         '8': "¡Vamos! Estamos muy muy cerca."
         '9': Ya casi...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing: Bloquear títulos existentes
@@ -4041,28 +4063,6 @@ es-ES:
       published_at: Publicado en
       restricted_regions: Regiones restringidas
       tags: Etiquetas
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/es-MX.yml
+++ b/locales/es-MX.yml
@@ -765,12 +765,18 @@ es-MX:
   average edits per day: ediciones promedio por día
   awards:
     add_nomination: Añadir nominación
+    admin:
+      delete:
     air_date:
       future: Se emite el %{date}
       past: Se emitió el %{date}
     alternative_names: Nombres alternativos
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: Categorías
       add_category:
       categories:
       category:
@@ -782,12 +788,9 @@ es-MX:
       locked:
       media_type:
       name:
+      title: Categorías
     category_empty: Sin nominaciones para esta categoría.
     ceremonies:
-      number: Número
-      release_date_max: Fecha de lanzamiento máxima
-      release_date_min: Fecha de lanzamiento mínima
-      title: Ceremonias
       add_ceremony:
       ceremonies:
       ceremony:
@@ -795,9 +798,23 @@ es-MX:
       limits:
       location:
       locked:
+      number: Número
+      release_date_max: Fecha de lanzamiento máxima
+      release_date_min: Fecha de lanzamiento mínima
+      title: Ceremonias
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      one: 1 Nominación
-      other: "%{count} Nominaciones"
       add_nomination:
       locked:
       movie:
@@ -805,6 +822,8 @@ es-MX:
       number:
         one:
         other:
+      one: 1 Nominación
+      other: "%{count} Nominaciones"
       title:
     nominee: Nominado
     show_info:
@@ -821,27 +840,10 @@ es-MX:
     wins:
       one: 1 Ganado
       other: "%{count} Ganados"
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Volver
+    ceremony:
     episode: Volver a episodio
     episode_groups: Volver a grupos de episodios
     episode_list: Volver a lista de episodios
@@ -852,8 +854,6 @@ es-MX:
     season_list: Volver a Lista de Temporadas
     to_tmdb: Volver a TMDB
     top: Ir Arriba
-    award:
-    ceremony:
   certifications:
     certification: Certificación
     descriptors: Descriptores
@@ -2213,6 +2213,7 @@ es-MX:
       wrong_length:
     movie:
       duplicate_cast: Esta persona ya ha sido agregada como miembro de Elenco
+    nesting:
     tv:
       create_season_locked: La creación de nuevas temporadas ha sido bloqueada para esta serie.
       duplicate_created_by: Esta persona ya ha sido agregada como Creador
@@ -2225,7 +2226,6 @@ es-MX:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: Fállo al enviar tu correo.
   failed_generic: Oops!, Hay un problema.
@@ -3564,6 +3564,22 @@ es-MX:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3582,6 +3598,9 @@ es-MX:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3624,6 +3643,9 @@ es-MX:
         '7': Solo un poco más...
         '8': "¡Vamos! Estamos cerca ahora."
         '9': Casi allí ...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3984,28 +4006,6 @@ es-MX:
       published_at:
       restricted_regions:
       tags: Etiquetas
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/es-PA.yml
+++ b/locales/es-PA.yml
@@ -765,12 +765,18 @@ es-PA:
   average edits per day: promedio de ediciones por día
   awards:
     add_nomination: Agregar nominación
+    admin:
+      delete:
     air_date:
       future: Se emite el %{date}
       past: Se transmitió el %{date}
     alternative_names: Nombres Alternativos
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: Categorías
       add_category:
       categories:
       category:
@@ -782,12 +788,9 @@ es-PA:
       locked:
       media_type:
       name:
+      title: Categorías
     category_empty: No hay nominaciones para esta categoría.
     ceremonies:
-      number: Número
-      release_date_max: Fecha de Lanzamiento Máxima
-      release_date_min: Fecha de Lanzamiento Mínima
-      title: Ceremonias
       add_ceremony:
       ceremonies:
       ceremony:
@@ -795,9 +798,23 @@ es-PA:
       limits:
       location:
       locked:
+      number: Número
+      release_date_max: Fecha de Lanzamiento Máxima
+      release_date_min: Fecha de Lanzamiento Mínima
+      title: Ceremonias
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      one: 1 Nominación
-      other: "%{count} Nominaciones"
       add_nomination:
       locked:
       movie:
@@ -805,6 +822,8 @@ es-PA:
       number:
         one:
         other:
+      one: 1 Nominación
+      other: "%{count} Nominaciones"
       title:
     nominee: Nominado
     show_info:
@@ -821,27 +840,10 @@ es-PA:
     wins:
       one: 1 Ganada
       other: "%{count} Ganadas"
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Volver
+    ceremony:
     episode: Volver al episodio
     episode_groups: Volver a los grupos de episodios
     episode_list: Volver a la lista de episodios
@@ -852,8 +854,6 @@ es-PA:
     season_list: Volver a la lista de temporadas
     to_tmdb: Volver a TMDB
     top:
-    award:
-    ceremony:
   certifications:
     certification:
     descriptors:
@@ -2161,6 +2161,7 @@ es-PA:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked: Se ha bloqueado la posibilidad de crear nuevas temporadas para esta serie.
       duplicate_created_by: Esta persona ya fue añadida como creador.
@@ -2173,7 +2174,6 @@ es-PA:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3507,6 +3507,22 @@ es-PA:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3525,6 +3541,9 @@ es-PA:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3567,6 +3586,9 @@ es-PA:
         '7': Solo un poco más...
         '8': "¡Apúrate! Estamos cerca."
         '9': Un poco más
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3927,28 +3949,6 @@ es-PA:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/eu-ES.yml
+++ b/locales/eu-ES.yml
@@ -765,12 +765,18 @@ eu-ES:
   average edits per day: batez besteko aldaketak eguneko
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -782,12 +788,9 @@ eu-ES:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -795,6 +798,22 @@ eu-ES:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -809,27 +828,10 @@ eu-ES:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Itzuli
+    ceremony:
     episode: Itzuli atalera
     episode_groups: Itzuli atal taldeetara
     episode_list: Itzuli atal zerrendara
@@ -840,8 +842,6 @@ eu-ES:
     season_list: Itzuli denboraldi zerrendara
     to_tmdb: Itzuli TMDbra
     top: Itzuli gora
-    award:
-    ceremony:
   certifications:
     certification: Egiaztapena
     descriptors:
@@ -2189,6 +2189,7 @@ eu-ES:
       wrong_length:
     movie:
       duplicate_cast: Pertsona hau dagoeneko gehitua dago aktore gisa.
+    nesting:
     tv:
       create_season_locked: Denboraldi berriak sortzeko aukera blokeatuta dago TB saio honentzat.
       duplicate_created_by: Pertsona hau dagoeneko gehitua dago sortzaile gisa.
@@ -2201,7 +2202,6 @@ eu-ES:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: Zure posta elektronikoa ez da ondo bidali.
   failed_generic: Arazo bat izan da.
@@ -3537,6 +3537,22 @@ eu-ES:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3555,6 +3571,9 @@ eu-ES:
           add: Gehitu Filma
           no_records: Ez da filmik gehitu.
       parts: Atalak
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3597,6 +3616,9 @@ eu-ES:
         '7': Pixka bat gehiago bakarrik...
         '8': Eutsi! Gertu gaude.
         '9': Ia iritsi gara...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3960,28 +3982,6 @@ eu-ES:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/fa-IR.yml
+++ b/locales/fa-IR.yml
@@ -763,12 +763,18 @@ fa-IR:
   average edits per day: متوسط ویرایش به‌ازای هر روز
   awards:
     add_nomination: افزودن نامزدی
+    admin:
+      delete:
     air_date:
       future: در %{date} پخش خواهد شد
       past: در %{date} پخش شد
     alternative_names: نام‌های جایگزین
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -780,12 +786,9 @@ fa-IR:
       locked:
       media_type:
       name:
+      title:
     category_empty: هیچ نامزدی برای این دسته وجود ندارد.
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title: مراسم‌ها
       add_ceremony:
       ceremonies:
       ceremony:
@@ -793,15 +796,31 @@ fa-IR:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title: مراسم‌ها
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      one: ۱ نامزدی
-      other: "%{count} نامزدی"
       add_nomination:
       locked:
       movie:
       nomination:
       number:
         other:
+      one: ۱ نامزدی
+      other: "%{count} نامزدی"
       title:
     nominee: نامزد شده
     show_info:
@@ -818,27 +837,10 @@ fa-IR:
     wins:
       one: ۱ برد
       other: "%{count} برد"
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: بازگشت
+    ceremony:
     episode: بازگشت به قسمت
     episode_groups: بازگشت به گروه‌های قسمت
     episode_list: بازگشت به فهرست قسمت
@@ -849,8 +851,6 @@ fa-IR:
     season_list: بازگشت به فهرست فصل
     to_tmdb: TMDB بازگشت به
     top: بازگشت به بالا
-    award:
-    ceremony:
   certifications:
     certification: گواهی
     descriptors: توصیف‌گرها
@@ -2205,6 +2205,7 @@ fa-IR:
       wrong_length:
     movie:
       duplicate_cast: این شخص پیشتر به‌عنوان یک بازیگر اضافه شده است.
+    nesting:
     tv:
       create_season_locked: ساخت فصل‌های جدید برای این سریال قفل شده است.
       duplicate_created_by: این فرد قبلا به‌عنوان سازنده اضافه شده است.
@@ -2217,7 +2218,6 @@ fa-IR:
       duplicate_season_episode_crew_member: این شخص قبلا به‌عنوان یک %{job_name} به قسمتی از این فصل اضافه شده است. عنوان‌بندی عوامل پشت دوربین باید به یک فصل یا یک قسمت اضافه شود و نه هر دو.
       missing_credit: عنوان‌بندی را که می‌خواهید ویرایش کنید وجود ندارد.
       missing_person: شخصی که وارد کردید پیدا نشد.
-    nesting:
     wrong_count:
   failed_email: ارسال ایمیل شما شکست خورد.
   failed_generic: مشکلی پیش آمد.
@@ -3562,6 +3562,22 @@ fa-IR:
   login_to_edit: به سیستم وارد شوید تا ویرایش کنید
   media:
     adult: بزرگسال
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: پاک‌سازی
@@ -3582,6 +3598,9 @@ fa-IR:
           add: افزودن فیلم
           no_records: هیچ فیلمی اضافه نشد.
       parts: بخش‌ها
+    companies:
+      companies:
+      select:
     company:
       headquarters: دفتر مرکزی
       movie_page_title: فیلم‌های تولید شده توسط %{name}
@@ -3624,6 +3643,9 @@ fa-IR:
         '7': فقط کمی بیشتر...
         '8': به تلاشت ادامه بده! الان دیگر به آخرش رسیدیم.
         '9': تقریبا تمومه...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing: قفل عناوین موجود
@@ -4002,28 +4024,6 @@ fa-IR:
       published_at: منتشر شده در
       restricted_regions: مناطق محدود
       tags: برچسب‌ها
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/fi-FI.yml
+++ b/locales/fi-FI.yml
@@ -765,12 +765,18 @@ fi-FI:
   average edits per day: muokkausta päivässä keskimäärin
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -782,12 +788,9 @@ fi-FI:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -795,6 +798,22 @@ fi-FI:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -809,27 +828,10 @@ fi-FI:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Takaisin
+    ceremony:
     episode: Takaisin jaksoon
     episode_groups: Takaisin jaksoryhmiin
     episode_list: Takaisin jaksoluetteloon
@@ -840,8 +842,6 @@ fi-FI:
     season_list: Takaisin kausiluetteloon
     to_tmdb: Takaisin TMDb:hen
     top: Takaisin ylös
-    award:
-    ceremony:
   certifications:
     certification: Luokitus
     descriptors: Kuvaajat
@@ -2202,6 +2202,7 @@ fi-FI:
       wrong_length:
     movie:
       duplicate_cast: Tämä henkilö on jo lisätty näyttelijäksi.
+    nesting:
     tv:
       create_season_locked: Uusien kausien luominen on lukittu tälle sarjalle.
       duplicate_created_by: Tämä henkilö on jo lisätty luojaksi.
@@ -2214,7 +2215,6 @@ fi-FI:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person: Lisäämääsi henkilöä ei löydy.
-    nesting:
     wrong_count:
   failed_email: Sähköpostisi lähettäminen epäonnistui.
   failed_generic: Ilmeni ongelma.
@@ -3559,6 +3559,22 @@ fi-FI:
   login_to_edit: Kirjaudu sisään muokataksesi
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Tyhjennä
@@ -3579,6 +3595,9 @@ fi-FI:
           add: Lisää elokuva
           no_records: Elokuvia ei ole lisätty.
       parts: Osat
+    companies:
+      companies:
+      select:
     company:
       headquarters: Pääkonttori
       movie_page_title: Elokuvat jotka on tuottanut %{name}
@@ -3621,6 +3640,9 @@ fi-FI:
         '7': Vielä pieni ponnistus...
         '8': Vielä jaksaa! Alkaa olla jo valmista.
         '9': Melkein valmista...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -4001,28 +4023,6 @@ fi-FI:
       published_at: Julkaistu
       restricted_regions: Rajoitetut alueet
       tags: Tunnisteet
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/fr-CA.yml
+++ b/locales/fr-CA.yml
@@ -767,12 +767,18 @@ fr-CA:
   average edits per day: moyenne de modifications par jour
   awards:
     add_nomination: Ajouter une nomination
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names: Noms alternatifs
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: Catégories
       add_category:
       categories:
       category:
@@ -784,12 +790,9 @@ fr-CA:
       locked:
       media_type:
       name:
+      title: Catégories
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -797,9 +800,23 @@ fr-CA:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      one: 1 nomination
-      other: "%{count} nominations"
       add_nomination:
       locked:
       movie:
@@ -807,6 +824,8 @@ fr-CA:
       number:
         one:
         other:
+      one: 1 nomination
+      other: "%{count} nominations"
       title:
     nominee:
     show_info:
@@ -821,27 +840,10 @@ fr-CA:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Retour
+    ceremony:
     episode: Retour à l'épisode
     episode_groups: Retour aux groupes d'épisodes
     episode_list: Retour à la liste des épisodes
@@ -852,8 +854,6 @@ fr-CA:
     season_list: Retour à la liste des saisons
     to_tmdb: Retour à TMDB
     top: Retour au début
-    award:
-    ceremony:
   certifications:
     certification: Classement
     descriptors: Descripteurs
@@ -2175,6 +2175,7 @@ fr-CA:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked: La création de nouvelles saisons a été verrouillée pour cette série.
       duplicate_created_by: Cette personne est déjà ajoutée en tant que créateur.
@@ -2187,7 +2188,6 @@ fr-CA:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person: La personne que vous avez entrée est introuvable.
-    nesting:
     wrong_count:
   failed_email: Votre courriel n'a pas pu être envoyé.
   failed_generic: Nous avons rencontré un problème.
@@ -3528,6 +3528,22 @@ fr-CA:
   login_to_edit: Connectez-vous pour contribuer
   media:
     adult: Adulte
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3546,6 +3562,9 @@ fr-CA:
           add: Ajouter un film
           no_records:
       parts: Partie
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title: Films produits par %{name}
@@ -3588,6 +3607,9 @@ fr-CA:
         '7': Encore un peu plus...
         '8': Allez! On y est presque.
         '9': Presque là...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3960,28 +3982,6 @@ fr-CA:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/fr-FR.yml
+++ b/locales/fr-FR.yml
@@ -767,12 +767,18 @@ fr-FR:
   average edits per day: 'modifications moyennes par jour '
   awards:
     add_nomination: Ajouter une nomination
+    admin:
+      delete:
     air_date:
       future: Diffusion prévue le %{date}
       past: Diffusée le %{date}
     alternative_names: Noms alternatifs
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: Catégories
       add_category:
       categories:
       category:
@@ -784,12 +790,9 @@ fr-FR:
       locked:
       media_type:
       name:
+      title: Catégories
     category_empty: Aucune nomination au sein de cette catégorie.
     ceremonies:
-      number: Numéro
-      release_date_max: Date de sortie + / -
-      release_date_min: Date de sortie - / +
-      title: Cérémonies
       add_ceremony:
       ceremonies:
       ceremony:
@@ -797,9 +800,23 @@ fr-FR:
       limits:
       location:
       locked:
+      number: Numéro
+      release_date_max: Date de sortie + / -
+      release_date_min: Date de sortie - / +
+      title: Cérémonies
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      one: 1 nomination
-      other: "%{count} nominations"
       add_nomination:
       locked:
       movie:
@@ -807,6 +824,8 @@ fr-FR:
       number:
         one:
         other:
+      one: 1 nomination
+      other: "%{count} nominations"
       title:
     nominee: Nominé·e
     show_info:
@@ -823,27 +842,10 @@ fr-FR:
     wins:
       one: 1 victoire
       other: "%{count} victoires"
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Retour
+    ceremony:
     episode: Retour à l'épisode
     episode_groups: Retour aux groupes d'épisodes
     episode_list: Retour à la liste des épisodes
@@ -854,8 +856,6 @@ fr-FR:
     season_list: Retour à la liste des saisons
     to_tmdb: Retour sur TMDB
     top: Retour vers le haut
-    award:
-    ceremony:
   certifications:
     certification: Classification d'âge
     descriptors: Descripteurs
@@ -2236,6 +2236,7 @@ fr-FR:
         other: n'ont pas les bonnes longueurs (qui doivent être de %{count} caractères)
     movie:
       duplicate_cast: Cette personne est déjà présente dans la distribution des rôles du film.
+    nesting:
     tv:
       create_season_locked: La création de nouvelles saisons a été verrouillée pour cette série.
       duplicate_created_by: Cette personne est déjà enregistrée comme créatrice ou créateur.
@@ -2248,7 +2249,6 @@ fr-FR:
       duplicate_season_episode_crew_member: Cette personne a déjà été ajoutée, en qualité de %{job_name}, à un épisode de cette saison. Les crédits de l'équipe technique doivent être ajoutés soit à une saison, soit à un épisode, mais pas aux deux.
       missing_credit: Le crédit que vous tentiez de modifier n'existe pas.
       missing_person: La personne que vous avez renseignée est introuvable.
-    nesting:
     wrong_count:
   failed_email: Votre courriel n'a pas pu être envoyé !<br>Merci de bien vouloir réessayer.<br>L'équipe de TMDB.
   failed_generic: Un problème est survenu.
@@ -3595,6 +3595,22 @@ fr-FR:
   login_to_edit: Connectez-vous afin de modifier cette fiche
   media:
     adult: Adulte
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Effacer
@@ -3615,6 +3631,9 @@ fr-FR:
           add: Ajouter un film à cette collection
           no_records: Aucun film n'a été ajouté.
       parts: Films dans cette collection
+    companies:
+      companies:
+      select:
     company:
       headquarters: Siège social
       movie_page_title: Films réalisés par %{name}
@@ -3657,6 +3676,9 @@ fr-FR:
         '7': Juste un peu plus...
         '8': Courage ! Nous sommes proches maintenant !
         '9': C'est presque bon !
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing: Verrouiller les titres existants
@@ -4037,28 +4059,6 @@ fr-FR:
       published_at: Publiée à
       restricted_regions: Régions restreintes
       tags: Mots-clés
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/gl-ES.yml
+++ b/locales/gl-ES.yml
@@ -763,12 +763,18 @@ gl-ES:
   average edits per day: Media de edicións ao día
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -780,12 +786,9 @@ gl-ES:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -793,6 +796,22 @@ gl-ES:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -807,27 +826,10 @@ gl-ES:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Voltar
+    ceremony:
     episode: Voltar ao episodio
     episode_groups: Voltar ao grupo de episodios
     episode_list: Volver á listaxe de episodios
@@ -838,8 +840,6 @@ gl-ES:
     season_list: Volver á listaxe de tempadas
     to_tmdb: Voltar á TMDB
     top: Voltar cara arriba
-    award:
-    ceremony:
   certifications:
     certification: Calificación
     descriptors: Descritores
@@ -2200,6 +2200,7 @@ gl-ES:
       wrong_length:
     movie:
       duplicate_cast: Esta persoa xa foi engadida como membro do equipo.
+    nesting:
     tv:
       create_season_locked: Bloqueouse a creación de novas tempadas para esta serie.
       duplicate_created_by: Esta persoa xa foi engadida como creador.
@@ -2212,7 +2213,6 @@ gl-ES:
       duplicate_season_episode_crew_member: Esta persoa xa se engadiu como %{job_name} a un episodio desta tempada. Os créditos do equipo deben engadirse a unha tempada ou a un episodio, e non a ambos.
       missing_credit: O crédito que estabas tentando editar non existe.
       missing_person: Non se puido atopar a persoa que introduciches.
-    nesting:
     wrong_count:
   failed_email: Non se puido enviar o teu email.
   failed_generic: Houbo un problema.
@@ -3550,6 +3550,22 @@ gl-ES:
   login_to_edit: Inicia sesión para editar
   media:
     adult: Adultos
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Limpar
@@ -3570,6 +3586,9 @@ gl-ES:
           add: Engadir película
           no_records: Non se engadiron películas.
       parts: Partes
+    companies:
+      companies:
+      select:
     company:
       headquarters: Oficina principal
       movie_page_title: Películas producidas por %{name}
@@ -3612,6 +3631,9 @@ gl-ES:
         '7': Un pouquichiño máis...
         '8': Dalle que chegamos!
         '9': Xa case estamos
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3992,28 +4014,6 @@ gl-ES:
       published_at: Publicado en
       restricted_regions: Rexións restrinxidas
       tags: Etiquetas
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/he-IL.yml
+++ b/locales/he-IL.yml
@@ -763,12 +763,18 @@ he-IL:
   average edits per day: ממוצע עריכות ליום
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -780,12 +786,9 @@ he-IL:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -793,6 +796,22 @@ he-IL:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -807,27 +826,10 @@ he-IL:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: אחורה
+    ceremony:
     episode: אחורה אל פרק
     episode_groups: אחורה אל קבוצות פרקים
     episode_list: אחורה אל רשימת פרקים
@@ -838,8 +840,6 @@ he-IL:
     season_list: אחורה אל רשימת עונות
     to_tmdb: אחורה אל TMDB
     top: אחורה אל ראש
-    award:
-    ceremony:
   certifications:
     certification: סיווג צפייה
     descriptors: מתארים
@@ -2197,6 +2197,7 @@ he-IL:
       wrong_length:
     movie:
       duplicate_cast: איש זה התווסף כבר בתור חבר להק
+    nesting:
     tv:
       create_season_locked: היצירה של עונות חדשות ננעלה עבור סדרה זו.
       duplicate_created_by: איש זה התווסף כבר בתור יוצר
@@ -2209,7 +2210,6 @@ he-IL:
       duplicate_season_episode_crew_member: ".אדם זה התווסף כבר כ%{job_name} אל פרק של העונה הזאת. קרדיטים של סגל צריכים להתווסף אל עונה או פרק, ולא אל שניהם"
       missing_credit: ".הקרדיט שאתה מנסה לערוך אינו קיים"
       missing_person: ".האדם שהכנסת לא היה יכול להימצא"
-    nesting:
     wrong_count:
   failed_email: ישנה בעיה בשליחת הדוא״ל שלך
   failed_generic: הייתה בעיה.
@@ -3556,6 +3556,22 @@ he-IL:
   login_to_edit: היכנס כדי לערוך
   media:
     adult: מבוגר
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: נקה
@@ -3576,6 +3592,9 @@ he-IL:
           add: הוסף סרט
           no_records: ".סרטים לא התווספו עדין"
       parts: חלקים
+    companies:
+      companies:
+      select:
     company:
       headquarters: מַטֶה
       movie_page_title: "%{name} סרטים שהופקו ע״י"
@@ -3618,6 +3637,9 @@ he-IL:
         '7': רק עוד קצת
         '8': אנחנו קרובים עכשיו
         '9': כמעט שם
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing: נעל כותרים קיימים
@@ -3998,28 +4020,6 @@ he-IL:
       published_at: פורסם ב
       restricted_regions: אזורים מוגבלים
       tags: תגיות
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/hi-IN.yml
+++ b/locales/hi-IN.yml
@@ -755,12 +755,18 @@ hi-IN:
   average edits per day:
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -772,12 +778,9 @@ hi-IN:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -785,6 +788,22 @@ hi-IN:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -799,27 +818,10 @@ hi-IN:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back:
+    ceremony:
     episode:
     episode_groups:
     episode_list:
@@ -830,8 +832,6 @@ hi-IN:
     season_list:
     to_tmdb:
     top:
-    award:
-    ceremony:
   certifications:
     certification: प्रमाणन
     descriptors:
@@ -2154,6 +2154,7 @@ hi-IN:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2166,7 +2167,6 @@ hi-IN:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3503,6 +3503,22 @@ hi-IN:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3521,6 +3537,9 @@ hi-IN:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3563,6 +3582,9 @@ hi-IN:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3923,28 +3945,6 @@ hi-IN:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/hr-HR.yml
+++ b/locales/hr-HR.yml
@@ -775,12 +775,18 @@ hr-HR:
   average edits per day: prosjek uređivanja po danu
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -792,12 +798,9 @@ hr-HR:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -805,6 +808,22 @@ hr-HR:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -819,27 +838,10 @@ hr-HR:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Povratak
+    ceremony:
     episode: Povratak na epizodu
     episode_groups: Povratak na grupu epizoda
     episode_list: Povratak na popis epizoda
@@ -850,8 +852,6 @@ hr-HR:
     season_list: Povratak na popis sezona
     to_tmdb: Povratak na TMDB
     top: Povratak na vrh
-    award:
-    ceremony:
   certifications:
     certification: Potvrda
     descriptors:
@@ -2219,6 +2219,7 @@ hr-HR:
       wrong_length:
     movie:
       duplicate_cast: Ta je osoba već dodana kao član postave.
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by: Ta je osoba već dodana kao autor.
@@ -2231,7 +2232,6 @@ hr-HR:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: Vaša e-pošta nije posalana.
   failed_generic: Došlo je do problema.
@@ -3573,6 +3573,22 @@ hr-HR:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Očisti
@@ -3591,6 +3607,9 @@ hr-HR:
           add: Dodaj film
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters: Glavno sjedište
       movie_page_title:
@@ -3633,6 +3652,9 @@ hr-HR:
         '7': Još samo malo...
         '8': Stisni zube! Sada smo blizu.
         '9': Skoro smo gotovi...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -4001,28 +4023,6 @@ hr-HR:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/hu-HU.yml
+++ b/locales/hu-HU.yml
@@ -763,12 +763,18 @@ hu-HU:
   average edits per day: átlagos napi szerkesztés
   awards:
     add_nomination: Jelölés hozzáadása
+    admin:
+      delete:
     air_date:
       future: Adásba kerülések %{date}
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -780,12 +786,9 @@ hu-HU:
       locked:
       media_type:
       name:
+      title:
     category_empty: Ebben a kategóriában nincsenek jelölések.
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -793,9 +796,23 @@ hu-HU:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      one: 1 jelölés
-      other: "%{count} jelölés"
       add_nomination:
       locked:
       movie:
@@ -803,6 +820,8 @@ hu-HU:
       number:
         one:
         other:
+      one: 1 jelölés
+      other: "%{count} jelölés"
       title:
     nominee: Jelölt
     show_info:
@@ -819,27 +838,10 @@ hu-HU:
     wins:
       one: 1 nyertes
       other: "%{count} nyertes"
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Vissza
+    ceremony:
     episode: Vissza az epizódhoz
     episode_groups: Vissza az epizód csoportokhoz
     episode_list: Vissza az epizódok listájához
@@ -850,8 +852,6 @@ hu-HU:
     season_list: Vissza az évadok listájához
     to_tmdb: Vissza az TMDb-re
     top: Vissza a tetejére
-    award:
-    ceremony:
   certifications:
     certification: Tanúsítvány
     descriptors:
@@ -2186,6 +2186,7 @@ hu-HU:
         other: nem megfelelő hosszúságú ( %{count} karakter legyen)
     movie:
       duplicate_cast: Ezt a személyt már hozzáadták a szereplőkhöz.
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by: Ezt a személyt már hozzáadták alkotóként.
@@ -2198,7 +2199,6 @@ hu-HU:
       duplicate_season_episode_crew_member:
       missing_credit: A szerkeszteni kívánt stáblista nem létezik.
       missing_person:
-    nesting:
     wrong_count:
   failed_email: Az e-mail elküldése sikertelen.
   failed_generic: Van egy kis probléma.
@@ -3537,6 +3537,22 @@ hu-HU:
   login_to_edit: Jelentkezz be szerkesztéshez
   media:
     adult: Felnőtt
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Törlés
@@ -3555,6 +3571,9 @@ hu-HU:
           add: Film hozzáadása
           no_records: Nincs film hozzáadva.
       parts: Részek
+    companies:
+      companies:
+      select:
     company:
       headquarters: Főhadiszállás
       movie_page_title:
@@ -3597,6 +3616,9 @@ hu-HU:
         '7': Csak egy kicsit még...
         '8': Gyerünk! Szinte már teljesen kész.
         '9': Még egy lépés...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3971,28 +3993,6 @@ hu-HU:
       published_at:
       restricted_regions:
       tags: Címkék
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/id-ID.yml
+++ b/locales/id-ID.yml
@@ -763,12 +763,18 @@ id-ID:
   average edits per day: Perhitungan suntingan per hari
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -780,12 +786,9 @@ id-ID:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -793,6 +796,22 @@ id-ID:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -807,27 +826,10 @@ id-ID:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Kembali
+    ceremony:
     episode: Kembali ke episode
     episode_groups:
     episode_list: Kembali ke daftar episode
@@ -838,8 +840,6 @@ id-ID:
     season_list: Kembali ke daftar musim
     to_tmdb: Kembali ke TMDB
     top: Kembali ke atas
-    award:
-    ceremony:
   certifications:
     certification: Sertifikasi
     descriptors:
@@ -2162,6 +2162,7 @@ id-ID:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2174,7 +2175,6 @@ id-ID:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: Surel anda gagal terkirim.
   failed_generic: Terjadi masalah.
@@ -3511,6 +3511,22 @@ id-ID:
   login_to_edit: Masuk untuk menyunting
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3529,6 +3545,9 @@ id-ID:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3571,6 +3590,9 @@ id-ID:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3931,28 +3953,6 @@ id-ID:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/it-IT.yml
+++ b/locales/it-IT.yml
@@ -765,12 +765,18 @@ it-IT:
   average edits per day: media modifiche al giorno
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: Categorie
       add_category:
       categories:
       category:
@@ -782,12 +788,9 @@ it-IT:
       locked:
       media_type:
       name:
+      title: Categorie
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -795,6 +798,22 @@ it-IT:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -809,27 +828,10 @@ it-IT:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Indietro
+    ceremony:
     episode: Torna all'episodio
     episode_groups: Torna ai gruppi episodi
     episode_list: Torna all'elenco degli episodi
@@ -840,8 +842,6 @@ it-IT:
     season_list: Torna all'elenco delle stagioni
     to_tmdb: Torna a TMDB
     top: Torna su
-    award:
-    ceremony:
   certifications:
     certification: Certificazione
     descriptors: Descrittori
@@ -2199,6 +2199,7 @@ it-IT:
       wrong_length:
     movie:
       duplicate_cast: La persona è già presente come membro del cast.
+    nesting:
     tv:
       create_season_locked: La creazione di nuove stagioni è stata bloccata per questa serie.
       duplicate_created_by: La persona è già presente come creatore.
@@ -2211,7 +2212,6 @@ it-IT:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: La tua e-mail non è stata inviata.
   failed_generic: C'è stato un problema.
@@ -3553,6 +3553,22 @@ it-IT:
   login_to_edit: Accedi per modificare
   media:
     adult: Per adulti
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Pulisci
@@ -3573,6 +3589,9 @@ it-IT:
           add: Aggiungi film
           no_records: Non sono stati aggiunti film.
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters: Quartier generale
       movie_page_title: Film prodotti da %{name}
@@ -3615,6 +3634,9 @@ it-IT:
         '7': Solo un altro po...
         '8': Forza! Siamo vicini ora.
         '9': Ci siamo quasi...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3991,28 +4013,6 @@ it-IT:
       published_at: Pubblicato Alle
       restricted_regions: Restrizione Paesi
       tags: Tags
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -765,12 +765,18 @@ ja-JP:
   average edits per day: 1日あたりの平均編集回数
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -782,12 +788,9 @@ ja-JP:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -795,6 +798,22 @@ ja-JP:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee: ノミネート
     show_info:
@@ -809,27 +828,10 @@ ja-JP:
     title: 受賞
     winner: 受賞者
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: 戻る
+    ceremony:
     episode: エピソードに戻る
     episode_groups: エピソードグループに戻る
     episode_list: エピソード一覧に戻る
@@ -840,8 +842,6 @@ ja-JP:
     season_list: シーズン一覧に戻る
     to_tmdb: TMDbに戻る
     top: トップに戻る
-    award:
-    ceremony:
   certifications:
     certification: 審査(年齢制限)
     descriptors:
@@ -2182,6 +2182,7 @@ ja-JP:
       wrong_length:
     movie:
       duplicate_cast: この人物はすでに出演者として追加されています。
+    nesting:
     tv:
       create_season_locked: このシリーズでは新シーズンの作成がロックされています。
       duplicate_created_by: この人物はすでにスタッフとして追加されています。
@@ -2194,7 +2195,6 @@ ja-JP:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: あなたのメールは送信できませんでした。
   failed_generic: 問題が発生しました。
@@ -3533,6 +3533,22 @@ ja-JP:
   login_to_edit: ログインして編集
   media:
     adult: アダルト
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: クリア
@@ -3553,6 +3569,9 @@ ja-JP:
           add: 映画を追加
           no_records: 追加された映画はありません。
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters: 本社所在地
       movie_page_title: "%{name}によって制作された映画"
@@ -3595,6 +3614,9 @@ ja-JP:
         '7': あともうちょっと…
         '8': 気合いを入れて！あともう少し。
         '9': もうすぐだ…
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3973,28 +3995,6 @@ ja-JP:
       published_at: 公開済み：
       restricted_regions: 制限地域
       tags: タグ
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/ka-GE.yml
+++ b/locales/ka-GE.yml
@@ -765,12 +765,18 @@ ka-GE:
   average edits per day: საშუალო რედაქტირებები დღეში
   awards:
     add_nomination: ნომინაციის დამატება
+    admin:
+      delete:
     air_date:
       future: ეთერში გასვლის თარიღი %{date}
       past: ეთერში გასვლის თარიღი %{date}
     alternative_names: ალტერნატიული სახელები
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: კატეგორიები
       add_category:
       categories:
       category:
@@ -782,12 +788,9 @@ ka-GE:
       locked:
       media_type:
       name:
+      title: კატეგორიები
     category_empty: ამ კატეგორიაში ნომინაციები არ მოიძებნა.
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title: ცერემონიები
       add_ceremony:
       ceremonies:
       ceremony:
@@ -795,6 +798,22 @@ ka-GE:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title: ცერემონიები
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee: ნომინანტი
     show_info:
@@ -809,27 +828,10 @@ ka-GE:
     title: ჯილდოები
     winner: გამარჯვებული
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: უკან
+    ceremony:
     episode: ეპიზოდზე დაბრუნება
     episode_groups: ეპიზოდის ჯგუფებში დაბრუნება
     episode_list: ეპიზოდების სიაში დაბრუნება
@@ -840,8 +842,6 @@ ka-GE:
     season_list: სეზონის სიაში დაბრუნება
     to_tmdb: TMDB-ზე დაბრუნება
     top: თავში დაბრუნება
-    award:
-    ceremony:
   certifications:
     certification: სერთიფიკატი
     descriptors: აღმწერები
@@ -2195,6 +2195,7 @@ ka-GE:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2207,7 +2208,6 @@ ka-GE:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: თქვენი ელფოსტა ვერ გაიგზავნა.
   failed_generic: წარმოიშვა პროლმება
@@ -3546,6 +3546,22 @@ ka-GE:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3566,6 +3582,9 @@ ka-GE:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title: "%{name}-ის მიერ წარმოებული ფილმები"
@@ -3608,6 +3627,9 @@ ka-GE:
         '7': სულ ცოტა მეტი...
         '8': ამოტუმბეთ! ჩვენ ახლა ახლოს ვართ.
         '9': თითქმის...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3970,28 +3992,6 @@ ka-GE:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/kk-KZ.yml
+++ b/locales/kk-KZ.yml
@@ -765,12 +765,18 @@ kk-KZ:
   average edits per day: kún boıynsha ortasha óńdemeler
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -782,12 +788,9 @@ kk-KZ:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -795,6 +798,22 @@ kk-KZ:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -809,27 +828,10 @@ kk-KZ:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Oralý
+    ceremony:
     episode: Epızodqa oralý
     episode_groups: Epızod toptaryna oralý
     episode_list: Epızod tizimine oralý
@@ -840,8 +842,6 @@ kk-KZ:
     season_list: Telemaýsym tizimine oralý
     to_tmdb: TMDB úshin oralý
     top: Joǵaryǵa oralý
-    award:
-    ceremony:
   certifications:
     certification: Kýálandyrý
     descriptors:
@@ -2174,6 +2174,7 @@ kk-KZ:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2186,7 +2187,6 @@ kk-KZ:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3522,6 +3522,22 @@ kk-KZ:
   login_to_edit: Óńdeý úshin kirińiz
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Tazalaý
@@ -3542,6 +3558,9 @@ kk-KZ:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters: Shtab-páter
       movie_page_title: "%{name} arqyly óńdirilgen fılmder"
@@ -3584,6 +3603,9 @@ kk-KZ:
         '7': Sál artyǵyraq qana...
         '8': Kúshteńiz! Qazir jetemiz.
         '9': Derlik jerdemiz
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3961,28 +3983,6 @@ kk-KZ:
       published_at: Jnynda jarıalanǵan
       restricted_regions: Shekteýli aımaqtar
       tags: Tegter
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/kn-IN.yml
+++ b/locales/kn-IN.yml
@@ -755,12 +755,18 @@ kn-IN:
   average edits per day:
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -772,12 +778,9 @@ kn-IN:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -785,6 +788,22 @@ kn-IN:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -799,27 +818,10 @@ kn-IN:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back:
+    ceremony:
     episode:
     episode_groups:
     episode_list:
@@ -830,8 +832,6 @@ kn-IN:
     season_list:
     to_tmdb:
     top:
-    award:
-    ceremony:
   certifications:
     certification:
     descriptors:
@@ -2154,6 +2154,7 @@ kn-IN:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2166,7 +2167,6 @@ kn-IN:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3500,6 +3500,22 @@ kn-IN:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3518,6 +3534,9 @@ kn-IN:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3560,6 +3579,9 @@ kn-IN:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3920,28 +3942,6 @@ kn-IN:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/ko-KR.yml
+++ b/locales/ko-KR.yml
@@ -763,12 +763,18 @@ ko-KR:
   average edits per day: 일 평균 편집수
   awards:
     add_nomination: 노미네이션 추가
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names: 다른 이름
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -780,12 +786,9 @@ ko-KR:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -793,6 +796,22 @@ ko-KR:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -807,27 +826,10 @@ ko-KR:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: 돌아가기
+    ceremony:
     episode: 에피소드로 돌아가기
     episode_groups: 에피소드 그룹으로 돌아가기
     episode_list: 에피소드 목록으로 돌아가기
@@ -838,8 +840,6 @@ ko-KR:
     season_list: 시즌 목록으로 돌아가기
     to_tmdb: TMDb로 돌아가기
     top: 맨 위로 돌아가기
-    award:
-    ceremony:
   certifications:
     certification: 등급
     descriptors: 설명
@@ -2168,6 +2168,7 @@ ko-KR:
       wrong_length:
     movie:
       duplicate_cast: 이미 출연진에 입력된 인물입니다.
+    nesting:
     tv:
       create_season_locked: 이 시리즈에서 새 시즌을 만들 수 없도록 잠겨있습니다.
       duplicate_created_by: 이미 추가되어 있습니다.
@@ -2180,7 +2181,6 @@ ko-KR:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: 메일 발송 실패
   failed_generic: 문제가 발생했습니다.
@@ -3525,6 +3525,22 @@ ko-KR:
   login_to_edit: 편집을 하시려면 로그인 하십시오.
   media:
     adult: 성인
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: 지우기
@@ -3545,6 +3561,9 @@ ko-KR:
           add: 영화 추가
           no_records: 추가된 영화가 없습니다
       parts: 파트
+    companies:
+      companies:
+      select:
     company:
       headquarters: 본사
       movie_page_title: "%{name} 제작 영화"
@@ -3587,6 +3606,9 @@ ko-KR:
         '7': 아주 조금만 더요
         '8': 힘내요! 거의 다 완성되어 가요.
         '9': 완성 직전입니다
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing: 제목을 잠급니다
@@ -3965,28 +3987,6 @@ ko-KR:
       published_at:
       restricted_regions: 제한 지역
       tags: 태그
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/ku-TR.yml
+++ b/locales/ku-TR.yml
@@ -756,12 +756,18 @@ ku-TR:
   average edits per day:
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -773,12 +779,9 @@ ku-TR:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -786,6 +789,22 @@ ku-TR:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -800,27 +819,10 @@ ku-TR:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back:
+    ceremony:
     episode:
     episode_groups:
     episode_list:
@@ -831,8 +833,6 @@ ku-TR:
     season_list:
     to_tmdb:
     top:
-    award:
-    ceremony:
   certifications:
     certification:
     descriptors:
@@ -2115,6 +2115,7 @@ ku-TR:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2127,7 +2128,6 @@ ku-TR:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3461,6 +3461,22 @@ ku-TR:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3479,6 +3495,9 @@ ku-TR:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3521,6 +3540,9 @@ ku-TR:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3881,28 +3903,6 @@ ku-TR:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/lt-LT.yml
+++ b/locales/lt-LT.yml
@@ -777,12 +777,18 @@ lt-LT:
   average edits per day: vidutiniškai taisymų per dieną
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -794,12 +800,9 @@ lt-LT:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -807,6 +810,22 @@ lt-LT:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -821,27 +840,10 @@ lt-LT:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Atgal
+    ceremony:
     episode: Atgal į epizodą
     episode_groups: Grįžti į epizodų grupes
     episode_list: Grįžti į epizodo sąrašą
@@ -852,8 +854,6 @@ lt-LT:
     season_list: Atgal į sezono sąrašą
     to_tmdb: Atgal į TMDB
     top: Atgal į viršų
-    award:
-    ceremony:
   certifications:
     certification: Amžiaus cenzas
     descriptors: Raktažodis
@@ -2297,6 +2297,7 @@ lt-LT:
       wrong_length:
     movie:
       duplicate_cast: Šis asmuo jau įtrauktas kaip aktorius.
+    nesting:
     tv:
       create_season_locked: Šiai serijai naujų sezonų kūrimas buvo užrakintas.
       duplicate_created_by: Šis asmuo jau yra pridėtas kaip autorius.
@@ -2309,7 +2310,6 @@ lt-LT:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: Jūsų el. laiško nepavyko išsiųsti.
   failed_generic: Įvyko klaida.
@@ -3659,6 +3659,22 @@ lt-LT:
   login_to_edit: Prisijunkite, jeigu norite redaguoti
   media:
     adult: Suaugusiems
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Išvalyti
@@ -3682,6 +3698,9 @@ lt-LT:
           add: Pridėti filmą
           no_records: Nebuvo pridėta jokių filmų.
       parts: Dalys
+    companies:
+      companies:
+      select:
     company:
       headquarters: Pagrindinė būstinė
       movie_page_title: Filmai sukurti %{name}
@@ -3724,6 +3743,9 @@ lt-LT:
         '7': Spustelk dar šiek tiek...
         '8': Varyk! Mes jau arti.
         '9': Ranka pasiekiama...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing: Užrakinti esamus titrus
@@ -4119,28 +4141,6 @@ lt-LT:
       published_at: Paskelbta
       restricted_regions: Riboti regionai
       tags: Žymos
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/lv-LV.yml
+++ b/locales/lv-LV.yml
@@ -775,12 +775,18 @@ lv-LV:
   average edits per day: vidējais labojumu skaits dienā
   awards:
     add_nomination: Pievienot izvirzīšanu
+    admin:
+      delete:
     air_date:
       future: Pirmizrāde būs %{date}
       past: Pirmizrāde bija %{date}
     alternative_names: Citi nosaukumi
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: Kategorijas
       add_category:
       categories:
       category:
@@ -792,12 +798,9 @@ lv-LV:
       locked:
       media_type:
       name:
+      title: Kategorijas
     category_empty: Šajā kategorijā nav izvirzīšanu
     ceremonies:
-      number: Skaits
-      release_date_max: Izlaišanas datums (jaunākais)
-      release_date_min: Izlaišanas datums (vecākais)
-      title: Svinīgas norises
       add_ceremony:
       ceremonies:
       ceremony:
@@ -805,10 +808,23 @@ lv-LV:
       limits:
       location:
       locked:
+      number: Skaits
+      release_date_max: Izlaišanas datums (jaunākais)
+      release_date_min: Izlaišanas datums (vecākais)
+      title: Svinīgas norises
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      one: "%{count} izvirzīšana"
-      other: "%{count} izvirzīšanas"
-      zero: "%{count} izvirzīšanu"
       add_nomination:
       locked:
       movie:
@@ -816,7 +832,10 @@ lv-LV:
       number:
         one:
         other:
+      one: "%{count} izvirzīšana"
+      other: "%{count} izvirzīšanas"
       title:
+      zero: "%{count} izvirzīšanu"
     nominee: Izvirzītais
     show_info:
       directed_by: Režisēja
@@ -833,27 +852,10 @@ lv-LV:
       one: "%{count} uzvara"
       other: "%{count} uzvaras"
       zero: "%{count} uzvaru"
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Atpakaļ
+    ceremony:
     episode: Atpakaļ uz sēriju
     episode_groups: Atgriezties uz sēriju kopām
     episode_list: Atgriezties uz sēriju sarakstu
@@ -864,8 +866,6 @@ lv-LV:
     season_list: Atpakaļ uz sezonu sarakstu
     to_tmdb: Atpakaļ uz TMDB
     top: Atpakaļ uz augšu
-    award:
-    ceremony:
   certifications:
     certification: Vecuma pārbaude
     descriptors: Atslēgvārds
@@ -2222,6 +2222,7 @@ lv-LV:
       wrong_length:
     movie:
       duplicate_cast: Šis cilvēks jau ir norādīta kā aktieru sastāva dalībnieks.
+    nesting:
     tv:
       create_season_locked: Jaunu sezonu izveide šim seriālam ir slēgta.
       duplicate_created_by: Šis asmuo jau ir pievienotas kā autorius.
@@ -2234,7 +2235,6 @@ lv-LV:
       duplicate_season_episode_crew_member: Šis cilvēks jau ir pievienots kā %{job_name} šīs sezonas sērijai. Komandas uzskaite ir jāpievieno vai nu sezonai, vai arī sērijai, bet ne abējādi.
       missing_credit: Uzskaitījumus, kuru tika mēģināts labot, nepastāv.
       missing_person: Ievadīto cilvēku nevarēja atrast.
-    nesting:
     wrong_count:
   failed_email: Neizdevās nosūtīt e-pasta ziņojumu.
   failed_generic: Radās sarežģījums.
@@ -3574,6 +3574,22 @@ lv-LV:
   login_to_edit: Jāpiesakās, lai labotu
   media:
     adult: Pieaugušais
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Notīrīt
@@ -3595,6 +3611,9 @@ lv-LV:
           add: Pievienot filmu
           no_records: Nav pievienota neviena filma.
       parts: Daļas
+    companies:
+      companies:
+      select:
     company:
       headquarters: Galvenā mītne
       movie_page_title: Filmas, kuras ir producējis %{name}
@@ -3637,6 +3656,9 @@ lv-LV:
         '7': Vēl tikai mazliet...
         '8': Saņemies! Mēs tagad esam tuvu.
         '9': Gandrīz galā...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing: Aizslēgt esošos nosaukumus
@@ -4024,28 +4046,6 @@ lv-LV:
       published_at: Publicēts
       restricted_regions: Ierobežotie apgabali
       tags: Birkas
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/ml-IN.yml
+++ b/locales/ml-IN.yml
@@ -755,12 +755,18 @@ ml-IN:
   average edits per day:
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -772,12 +778,9 @@ ml-IN:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -785,6 +788,22 @@ ml-IN:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -799,27 +818,10 @@ ml-IN:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back:
+    ceremony:
     episode:
     episode_groups:
     episode_list:
@@ -830,8 +832,6 @@ ml-IN:
     season_list:
     to_tmdb:
     top:
-    award:
-    ceremony:
   certifications:
     certification:
     descriptors:
@@ -2154,6 +2154,7 @@ ml-IN:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2166,7 +2167,6 @@ ml-IN:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3500,6 +3500,22 @@ ml-IN:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3518,6 +3534,9 @@ ml-IN:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3560,6 +3579,9 @@ ml-IN:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3920,28 +3942,6 @@ ml-IN:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/nb-NO.yml
+++ b/locales/nb-NO.yml
@@ -755,12 +755,18 @@ nb-NO:
   average edits per day:
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -772,12 +778,9 @@ nb-NO:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -785,6 +788,22 @@ nb-NO:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -799,27 +818,10 @@ nb-NO:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back:
+    ceremony:
     episode:
     episode_groups:
     episode_list:
@@ -830,8 +832,6 @@ nb-NO:
     season_list:
     to_tmdb:
     top:
-    award:
-    ceremony:
   certifications:
     certification:
     descriptors:
@@ -2154,6 +2154,7 @@ nb-NO:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2166,7 +2167,6 @@ nb-NO:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3503,6 +3503,22 @@ nb-NO:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3521,6 +3537,9 @@ nb-NO:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3563,6 +3582,9 @@ nb-NO:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3923,28 +3945,6 @@ nb-NO:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/nl-BE.yml
+++ b/locales/nl-BE.yml
@@ -755,12 +755,18 @@ nl-BE:
   average edits per day:
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -772,12 +778,9 @@ nl-BE:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -785,6 +788,22 @@ nl-BE:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -799,27 +818,10 @@ nl-BE:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back:
+    ceremony:
     episode:
     episode_groups:
     episode_list:
@@ -830,8 +832,6 @@ nl-BE:
     season_list:
     to_tmdb:
     top:
-    award:
-    ceremony:
   certifications:
     certification:
     descriptors:
@@ -2114,6 +2114,7 @@ nl-BE:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2126,7 +2127,6 @@ nl-BE:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3460,6 +3460,22 @@ nl-BE:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3478,6 +3494,9 @@ nl-BE:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3520,6 +3539,9 @@ nl-BE:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3880,28 +3902,6 @@ nl-BE:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/nl-NL.yml
+++ b/locales/nl-NL.yml
@@ -765,12 +765,18 @@ nl-NL:
   average edits per day: gemiddeld aantal bewerkingen per dag
   awards:
     add_nomination: Nominatie toevoegen
+    admin:
+      delete:
     air_date:
       future: Uitgezonden op %{date}
       past: Uitgezonden op %{date}
     alternative_names: Alternatieve namen
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: Categorieën
       add_category:
       categories:
       category:
@@ -782,12 +788,9 @@ nl-NL:
       locked:
       media_type:
       name:
+      title: Categorieën
     category_empty: Geen nominaties in deze categorie.
     ceremonies:
-      number: Nummer
-      release_date_max: Uitgebracht op max
-      release_date_min: Uitgebracht op min
-      title: Ceremonies
       add_ceremony:
       ceremonies:
       ceremony:
@@ -795,9 +798,23 @@ nl-NL:
       limits:
       location:
       locked:
+      number: Nummer
+      release_date_max: Uitgebracht op max
+      release_date_min: Uitgebracht op min
+      title: Ceremonies
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      one: 1 nominatie
-      other: "%{count} nominaties"
       add_nomination:
       locked:
       movie:
@@ -805,6 +822,8 @@ nl-NL:
       number:
         one:
         other:
+      one: 1 nominatie
+      other: "%{count} nominaties"
       title:
     nominee: Genomineerde
     show_info:
@@ -821,27 +840,10 @@ nl-NL:
     wins:
       one: 1 overwinning
       other: "%{count} overwinningen"
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Terug
+    ceremony:
     episode: Terug naar aflevering
     episode_groups: Terug naar afleveringengroepen
     episode_list: Terug naar afleveringenlijst
@@ -852,8 +854,6 @@ nl-NL:
     season_list: Terug naar seizoenslijst
     to_tmdb: Terug naar TMDB
     top: Terug naar boven
-    award:
-    ceremony:
   certifications:
     certification: Classificatie
     descriptors: Beschrijvingen
@@ -2211,6 +2211,7 @@ nl-NL:
       wrong_length:
     movie:
       duplicate_cast: Deze persoon is al toegevoegd als castlid.
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by: Deze persoon is al toegevoegd als maker.
@@ -2223,7 +2224,6 @@ nl-NL:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: Het versturen van je e-mail is mislukt.
   failed_generic: Er heeft zich een probleem voorgedaan.
@@ -3562,6 +3562,22 @@ nl-NL:
   login_to_edit: Log in om te bewerken
   media:
     adult: Erotiek
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Wissen
@@ -3582,6 +3598,9 @@ nl-NL:
           add: Film toevoegen
           no_records: Geen films toegevoegd.
       parts: Delen
+    companies:
+      companies:
+      select:
     company:
       headquarters: Hoofdkantoor
       movie_page_title: Films geproduceerd door %{name}
@@ -3624,6 +3643,9 @@ nl-NL:
         '7': Nog een klein beetje...
         '8': Nog even! We zijn er bijna.
         '9': Bijna klaar...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing: Huidige titles vergrendelen
@@ -4004,28 +4026,6 @@ nl-NL:
       published_at: Gepubliceerd op
       restricted_regions: Beperkte regio's
       tags: Labels
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/no-NO.yml
+++ b/locales/no-NO.yml
@@ -765,12 +765,18 @@ no-NO:
   average edits per day: gjennomsnittlig endringer per dag
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -782,12 +788,9 @@ no-NO:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -795,6 +798,22 @@ no-NO:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -809,27 +828,10 @@ no-NO:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Tilbake
+    ceremony:
     episode: Tilbake til episode
     episode_groups: Tilbkae til episodegruppene
     episode_list: Tilbake til episodelisten
@@ -840,8 +842,6 @@ no-NO:
     season_list: Tilbake til sesonglisten
     to_tmdb: Tilbake til TMDB
     top: Tilbake til toppen
-    award:
-    ceremony:
   certifications:
     certification: Klassifisering
     descriptors: Beskrivere
@@ -2172,6 +2172,7 @@ no-NO:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2184,7 +2185,6 @@ no-NO:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: Feil ved sending av e-post.
   failed_generic: En feil har oppstått.
@@ -3526,6 +3526,22 @@ no-NO:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3544,6 +3560,9 @@ no-NO:
           add: Legg til film
           no_records: Ingen filmer har blitt lagt til
       parts: Deler
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3586,6 +3605,9 @@ no-NO:
         '7': Bare litt til…
         '8': Kjør på! Vi er nærme nå.
         '9': Nesten der…
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing: Lås eksisterende titler
@@ -3951,28 +3973,6 @@ no-NO:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/oc-FR.yml
+++ b/locales/oc-FR.yml
@@ -755,12 +755,18 @@ oc-FR:
   average edits per day:
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -772,12 +778,9 @@ oc-FR:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -785,6 +788,22 @@ oc-FR:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -799,27 +818,10 @@ oc-FR:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back:
+    ceremony:
     episode:
     episode_groups:
     episode_list:
@@ -830,8 +832,6 @@ oc-FR:
     season_list:
     to_tmdb:
     top:
-    award:
-    ceremony:
   certifications:
     certification:
     descriptors:
@@ -2114,6 +2114,7 @@ oc-FR:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2126,7 +2127,6 @@ oc-FR:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3460,6 +3460,22 @@ oc-FR:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3478,6 +3494,9 @@ oc-FR:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3520,6 +3539,9 @@ oc-FR:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3880,28 +3902,6 @@ oc-FR:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/pl-PL.yml
+++ b/locales/pl-PL.yml
@@ -777,12 +777,18 @@ pl-PL:
   average edits per day: średnio edycji na dzień
   awards:
     add_nomination: Dodaj nominację
+    admin:
+      delete:
     air_date:
       future: Emisje %{date}
       past: Emitowany %{date}
     alternative_names: Alternatywne nazwy
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: Kategorie
       add_category:
       categories:
       category:
@@ -794,12 +800,9 @@ pl-PL:
       locked:
       media_type:
       name:
+      title: Kategorie
     category_empty: Brak nominacji w tej kategorii
     ceremonies:
-      number: Liczba
-      release_date_max: Data wydania Max
-      release_date_min: Data wydania Min
-      title: Ceremonie
       add_ceremony:
       ceremonies:
       ceremony:
@@ -807,19 +810,35 @@ pl-PL:
       limits:
       location:
       locked:
+      number: Liczba
+      release_date_max: Data wydania Max
+      release_date_min: Data wydania Min
+      title: Ceremonie
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      few: "%{count} nominacje"
-      one: 1 nominacja
-      other: "%{count} nominacji"
       add_nomination:
+      few: "%{count} nominacje"
       locked:
       movie:
       nomination:
       number:
-        one:
         few:
         many:
+        one:
         other:
+      one: 1 nominacja
+      other: "%{count} nominacji"
       title:
     nominee: Nominowany
     show_info:
@@ -834,27 +853,10 @@ pl-PL:
     title: Nagrody
     winner: Zwycięzca
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Wróć
+    ceremony:
     episode: Wróć do odcinka
     episode_groups: Powrót do grup odcinków
     episode_list: Wróć do listy odcinków
@@ -865,8 +867,6 @@ pl-PL:
     season_list: Wróć do listy sezonów
     to_tmdb: Wróć do TMDB
     top: Wróć do góry
-    award:
-    ceremony:
   certifications:
     certification: Certyfikacja
     descriptors:
@@ -2229,6 +2229,7 @@ pl-PL:
       wrong_length:
     movie:
       duplicate_cast: Ta osoba jest już dodana jako członek obsady.
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by: Ta osoba już została dodana jako twórca.
@@ -2241,7 +2242,6 @@ pl-PL:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: Wystąpił błąd przy wysyłaniu e-maila.
   failed_generic: Wystąpił problem.
@@ -3586,6 +3586,22 @@ pl-PL:
   login_to_edit: Zaloguj się, aby edytować
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3604,6 +3620,9 @@ pl-PL:
           add: Dodaj film
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters: Siedziba
       movie_page_title:
@@ -3646,6 +3665,9 @@ pl-PL:
         '7': Jeszcze tylko troszeczkę...
         '8': Jesteśmy już tak blisko!
         '9': Już prawie...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -4006,28 +4028,6 @@ pl-PL:
       published_at:
       restricted_regions:
       tags: Tagi
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/pt-BR.yml
+++ b/locales/pt-BR.yml
@@ -781,12 +781,18 @@ pt-BR:
   average edits per day: média de edições por dia
   awards:
     add_nomination: Adicionar indicação
+    admin:
+      delete:
     air_date:
       future: Exibição em %{date}
       past: Exibido em %{date}
     alternative_names: Nomes Alternativos
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: Categorias
       add_category:
       categories:
       category:
@@ -798,12 +804,9 @@ pt-BR:
       locked:
       media_type:
       name:
+      title: Categorias
     category_empty: Não há indicações para esta categoria.
     ceremonies:
-      number: Número
-      release_date_max: Estréia
-      release_date_min:
-      title: Cerimônias
       add_ceremony:
       ceremonies:
       ceremony:
@@ -811,9 +814,23 @@ pt-BR:
       limits:
       location:
       locked:
+      number: Número
+      release_date_max: Estréia
+      release_date_min:
+      title: Cerimônias
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      one: Uma indicação
-      other: "%{count} Indicações"
       add_nomination:
       locked:
       movie:
@@ -821,6 +838,8 @@ pt-BR:
       number:
         one:
         other:
+      one: Uma indicação
+      other: "%{count} Indicações"
       title:
     nominee: Indicado
     show_info:
@@ -837,27 +856,10 @@ pt-BR:
     wins:
       one: 1 Vitória
       other: "%{count} Vitórias"
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Voltar
+    ceremony:
     episode: Voltar à lista de episódios
     episode_groups: Voltar aos grupos de episódios
     episode_list: Voltar à lista de episódios
@@ -868,8 +870,6 @@ pt-BR:
     season_list: Voltar à lista de temporadas
     to_tmdb: Voltar ao TMDB
     top: Voltar ao topo
-    award:
-    ceremony:
   certifications:
     certification: Classificação Indicativa
     descriptors: Descritores
@@ -2240,6 +2240,7 @@ pt-BR:
       wrong_length:
     movie:
       duplicate_cast: Esta pessoa já foi adicionada como um membro do elenco.
+    nesting:
     tv:
       create_season_locked: A criação de novas temporadas foi bloqueada para esta série.
       duplicate_created_by: Esta pessoa já foi adicionada como um(a) criador(a).
@@ -2252,7 +2253,6 @@ pt-BR:
       duplicate_season_episode_crew_member: Esta pessoa já foi adicionada como %{job_name} a um episódio desta temporada.  Os créditos da equipe precisam ser adicionados a uma temporada ou a um episódio, e não a ambos.
       missing_credit: O crédito que você estava tentando editar não existe.
       missing_person: A pessoa que você digitou não foi encontrada.
-    nesting:
     wrong_count:
   failed_email: Ocorreu um problema ao enviar seu e-mail.
   failed_generic: Ocorreu um problema.
@@ -3603,6 +3603,22 @@ pt-BR:
   login_to_edit: Entre com uma conta para editar
   media:
     adult: Adulto
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Limpar
@@ -3623,6 +3639,9 @@ pt-BR:
           add: Adicionar Filme
           no_records: Nenhum Filme foi adicionado.
       parts: Itens
+    companies:
+      companies:
+      select:
     company:
       headquarters: Sede
       movie_page_title: Filmes produzidos por %{name}
@@ -3665,6 +3684,9 @@ pt-BR:
         '7': Só mais um pouquinho...
         '8': Não desanima não! Estamos tão perto.
         '9': Quase lá...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing: Bloquear Títulos Existentes
@@ -4047,28 +4069,6 @@ pt-BR:
       published_at: Publicado em
       restricted_regions: Regiões restritas
       tags: Marcadores
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/pt-PT.yml
+++ b/locales/pt-PT.yml
@@ -765,12 +765,18 @@ pt-PT:
   average edits per day: média de edições por dia
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -782,12 +788,9 @@ pt-PT:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -795,6 +798,22 @@ pt-PT:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -809,27 +828,10 @@ pt-PT:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Voltar
+    ceremony:
     episode: Voltar ao Episódio
     episode_groups: Voltar ao Grupo de Episódios
     episode_list: Voltar a Lista de Episódios
@@ -840,8 +842,6 @@ pt-PT:
     season_list: Voltar à lista de temporadas
     to_tmdb: Voltar ao TMDB
     top: Voltar ao Topo
-    award:
-    ceremony:
   certifications:
     certification: Classificação Etária
     descriptors: Descritores
@@ -2198,6 +2198,7 @@ pt-PT:
       wrong_length:
     movie:
       duplicate_cast: Esta pessoa já foi adicionada ao elenco.
+    nesting:
     tv:
       create_season_locked: A criação de novas temporadas foi bloqueada para esta série.
       duplicate_created_by: Esta pessoa já foi adicionada como um(a) criador(a).
@@ -2210,7 +2211,6 @@ pt-PT:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: E-mail não enviado.
   failed_generic: Houve um problema.
@@ -3551,6 +3551,22 @@ pt-PT:
   login_to_edit: Iniciar Sessão para Editar
   media:
     adult: Adulto
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Eliminar Filtro
@@ -3571,6 +3587,9 @@ pt-PT:
           add: Adicionar filme
           no_records: Não foi adicionado nenhum filme.
       parts: Partes
+    companies:
+      companies:
+      select:
     company:
       headquarters: Sede
       movie_page_title: Filmes produzidos por %{name}
@@ -3613,6 +3632,9 @@ pt-PT:
         '7': Só mais um pouquinho...
         '8': Não desanime! Estamos tão perto.
         '9': Quase lá...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3991,28 +4013,6 @@ pt-PT:
       published_at: Publicado em
       restricted_regions: Regiões Restringidas
       tags: Etiquetas "Tags"
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/ro-RO.yml
+++ b/locales/ro-RO.yml
@@ -783,12 +783,18 @@ ro-RO:
   average edits per day: Medie de modificări pe zi
   awards:
     add_nomination: Adăugare nominalizare
+    admin:
+      delete:
     air_date:
       future: Se difuzează pe data de %{date}
       past: A fost difuzat pe data de %{date}
     alternative_names: Nume alternative
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: Categorii
       add_category:
       categories:
       category:
@@ -800,12 +806,9 @@ ro-RO:
       locked:
       media_type:
       name:
+      title: Categorii
     category_empty: Nicio nominalizare pentru această categorie.
     ceremonies:
-      number: Număr
-      release_date_max: Dată de lansare maximă
-      release_date_min: Dată de lansare minimă
-      title: Ceremonii
       add_ceremony:
       ceremonies:
       ceremony:
@@ -813,18 +816,34 @@ ro-RO:
       limits:
       location:
       locked:
+      number: Număr
+      release_date_max: Dată de lansare maximă
+      release_date_min: Dată de lansare minimă
+      title: Ceremonii
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      few: "%{count} nominalizări"
-      one: O nominalizare
-      other: "%{count} de nominalizări"
       add_nomination:
+      few: "%{count} nominalizări"
       locked:
       movie:
       nomination:
       number:
-        one:
         few:
+        one:
         other:
+      one: O nominalizare
+      other: "%{count} de nominalizări"
       title:
     nominee: Nominalizat
     show_info:
@@ -842,27 +861,10 @@ ro-RO:
       few: "%{count} victorii"
       one: O victorie
       other: "%{count} de victorii"
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Înapoi
+    ceremony:
     episode: Înapoi la episod
     episode_groups: Înapoi la grupul de episoade
     episode_list: Înapoi la lista de episoade
@@ -873,8 +875,6 @@ ro-RO:
     season_list: Înapoi la lista de sezoane
     to_tmdb: Înapoi la TMDB
     top: Înapoi sus
-    award:
-    ceremony:
   certifications:
     certification: Certificare
     descriptors: Descriatori
@@ -2270,6 +2270,7 @@ ro-RO:
         other: are lungimea greșită (ar trebui să aibă %{count} de caractere)
     movie:
       duplicate_cast: Această persoană a fost deja adăugată ca membru al distribuției.
+    nesting:
     tv:
       create_season_locked: Crearea de noi sezoane a fost blocată pentru această serie.
       duplicate_created_by: Această persoană a fost deja adăugată ca și realizator.
@@ -2282,7 +2283,6 @@ ro-RO:
       duplicate_season_episode_crew_member: Această persoană este deja adăugată ca %{job_name} la un episod din acest sezon. Creditele echipei trebuie adăugate fie la un sezon, fie la un episod, și nu la ambele.
       missing_credit: Creditul pe care încercați să îl editați nu există.
       missing_person: Persoana pe care ați introdus-o nu a putut fi găsită.
-    nesting:
     wrong_count:
   failed_email: Email-ul tău nu a putut fi trimis.
   failed_generic: A intervenit o problemă.
@@ -3632,6 +3632,22 @@ ro-RO:
   login_to_edit: Autentificați-vă pentru a edita
   media:
     adult: Adult
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Curăță
@@ -3653,6 +3669,9 @@ ro-RO:
           add: Adăugare film artistic
           no_records: Nu s-au adăugat filme artistice.
       parts: Părți
+    companies:
+      companies:
+      select:
     company:
       headquarters: Sediu
       movie_page_title: Filme produse de %{name}
@@ -3695,6 +3714,9 @@ ro-RO:
         '7': Încă un pic mai mult...
         '8': Forțați! Suntem aproape acum.
         '9': Aproape acolo...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing: Blochează titlurile existente
@@ -4082,28 +4104,6 @@ ro-RO:
       published_at: Publicat la
       restricted_regions: Regiuni restricționate
       tags: Etichete
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/ru-RU.yml
+++ b/locales/ru-RU.yml
@@ -777,12 +777,18 @@ ru-RU:
   average edits per day: в среднем, правок за день
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -794,12 +800,9 @@ ru-RU:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -807,6 +810,22 @@ ru-RU:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -821,27 +840,10 @@ ru-RU:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Назад
+    ceremony:
     episode: Назад к эпизоду
     episode_groups: Назад к группе эпизодов
     episode_list: Назад к списку эпизодов
@@ -852,8 +854,6 @@ ru-RU:
     season_list: Назад к списку сезонов
     to_tmdb: Назад к TMDB
     top: Наверх
-    award:
-    ceremony:
   certifications:
     certification: Возрастная категория
     descriptors:
@@ -2223,6 +2223,7 @@ ru-RU:
       wrong_length:
     movie:
       duplicate_cast: Эта персона уже добавлена в актёрский состав.
+    nesting:
     tv:
       create_season_locked: Создание новых сезонов для этого сериала заблокировано.
       duplicate_created_by: Эта персона уже добавлена как создатель.
@@ -2235,7 +2236,6 @@ ru-RU:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: Не удалось отправить ваше письмо.
   failed_generic: Возникла проблема.
@@ -3587,6 +3587,22 @@ ru-RU:
   login_to_edit: Войти для правки
   media:
     adult: Для взрослых
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Очистить
@@ -3609,6 +3625,9 @@ ru-RU:
           add: Добавить фильм
           no_records: Нет добавленных фильмов
       parts: Части
+    companies:
+      companies:
+      select:
     company:
       headquarters: Штаб-квартира
       movie_page_title: Фильмы, созданные %{name}
@@ -3651,6 +3670,9 @@ ru-RU:
         '7': Еще немного, еще чуть-чуть.
         '8': Поднажми! Уже почти у цели.
         '9': Почти готово...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -4045,28 +4067,6 @@ ru-RU:
       published_at: Опубликовано на
       restricted_regions: Ограничение По Регионам
       tags: Теги
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/sk-SK.yml
+++ b/locales/sk-SK.yml
@@ -767,12 +767,18 @@ sk-SK:
   average edits per day: premierne úprav za deň
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -784,12 +790,9 @@ sk-SK:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -797,6 +800,22 @@ sk-SK:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -811,27 +830,10 @@ sk-SK:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Späť
+    ceremony:
     episode: Späť na epizódu
     episode_groups: Späť na skupinu epizód
     episode_list: Späť na zoznam epizód
@@ -842,8 +844,6 @@ sk-SK:
     season_list: Späť na zoznam sérií
     to_tmdb: Späť na TMDB
     top: Späť na vrch
-    award:
-    ceremony:
   certifications:
     certification: Prístupnosť
     descriptors:
@@ -2206,6 +2206,7 @@ sk-SK:
       wrong_length:
     movie:
       duplicate_cast: Táto osoba je už pridaná ako člen štábu.
+    nesting:
     tv:
       create_season_locked: Vytváranie nových sérií bolo pre tento seriál zamknuté.
       duplicate_created_by: Táto osoba je už pridaná ako tvorca.
@@ -2218,7 +2219,6 @@ sk-SK:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: Odoslanie emailu zlyhalo.
   failed_generic: Nastal problém.
@@ -3559,6 +3559,22 @@ sk-SK:
   login_to_edit: Prihlás sa pre úpravu
   media:
     adult: Pre dospelých
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Vyčistiť
@@ -3580,6 +3596,9 @@ sk-SK:
           add: Pridať film
           no_records: Neboli pridané žiadne filmy.
       parts: Časti
+    companies:
+      companies:
+      select:
     company:
       headquarters: Centrála
       movie_page_title: Film produkovaný %{name}
@@ -3622,6 +3641,9 @@ sk-SK:
         '7': Chce to ešte trochu viac...
         '8': Nevzdávame sa! Už sme tak blízko.
         '9': Už sme takmer tam...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -4009,28 +4031,6 @@ sk-SK:
       published_at: Publikované na
       restricted_regions: Obmedzené regióny
       tags: Tagy
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/sl-SI.yml
+++ b/locales/sl-SI.yml
@@ -775,12 +775,18 @@ sl-SI:
   average edits per day: povprečno urejanj na dan
   awards:
     add_nomination: Dodaj nominacijo
+    admin:
+      delete:
     air_date:
       future: Izide %{date}
       past: Izšlo %{date}
     alternative_names: Alternativni nazivi
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: Kategorije
       add_category:
       categories:
       category:
@@ -792,12 +798,9 @@ sl-SI:
       locked:
       media_type:
       name:
+      title: Kategorije
     category_empty: Za to kategorijo ni nominacij.
     ceremonies:
-      number:
-      release_date_max: Najpoznejši datum izida
-      release_date_min: Najzgodnejši datum izida
-      title: Slovesnosti
       add_ceremony:
       ceremonies:
       ceremony:
@@ -805,21 +808,37 @@ sl-SI:
       limits:
       location:
       locked:
+      number:
+      release_date_max: Najpoznejši datum izida
+      release_date_min: Najzgodnejši datum izida
+      title: Slovesnosti
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      few: "%{count} nominacije"
-      one: 1 nominacija
-      other: "%{count} nominacij"
-      two: "%{count} nominaciji"
       add_nomination:
+      few: "%{count} nominacije"
       locked:
       movie:
       nomination:
       number:
-        one:
-        two:
         few:
+        one:
         other:
+        two:
+      one: 1 nominacija
+      other: "%{count} nominacij"
       title:
+      two: "%{count} nominaciji"
     nominee: Nominiranec
     show_info:
       directed_by: Režija
@@ -837,27 +856,10 @@ sl-SI:
       one: 1 zmaga
       other: "%{count} zmag"
       two: "%{count} zmagi"
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Nazaj
+    ceremony:
     episode: Nazaj na epizodo
     episode_groups: Nazaj na skupine epizod
     episode_list: Nazaj na seznam epizod
@@ -868,8 +870,6 @@ sl-SI:
     season_list: Nazaj na seznam sezon
     to_tmdb: Nazaj na TMDB
     top: Nazaj na vrh
-    award:
-    ceremony:
   certifications:
     certification: Certifikat
     descriptors: Opisniki
@@ -2209,6 +2209,7 @@ sl-SI:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2221,7 +2222,6 @@ sl-SI:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3560,6 +3560,22 @@ sl-SI:
   login_to_edit: Za urejanje se prijavite
   media:
     adult: Odraslo
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Počisti
@@ -3582,6 +3598,9 @@ sl-SI:
           add: Dodaj film
           no_records: Ni dodanih filmov.
       parts: Deli
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3624,6 +3643,9 @@ sl-SI:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing: Zakleni obstoječe naslove
@@ -3984,28 +4006,6 @@ sl-SI:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/so-SO.yml
+++ b/locales/so-SO.yml
@@ -765,12 +765,18 @@ so-SO:
   average edits per day: celceliska wax beddelida maalintii
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -782,12 +788,9 @@ so-SO:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -795,6 +798,22 @@ so-SO:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -809,27 +828,10 @@ so-SO:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Dib
+    ceremony:
     episode: Ku noqo xalqada
     episode_groups: Ku noqo kooxaha xalqada
     episode_list: Ku noqo liiska xalqada
@@ -840,8 +842,6 @@ so-SO:
     season_list: Ku noqo liiska xilliga
     to_tmdb: Ku noqo TMDB
     top: Ku noqo sare
-    award:
-    ceremony:
   certifications:
     certification: Shahaado
     descriptors:
@@ -2133,6 +2133,7 @@ so-SO:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2145,7 +2146,6 @@ so-SO:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3479,6 +3479,22 @@ so-SO:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3497,6 +3513,9 @@ so-SO:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3539,6 +3558,9 @@ so-SO:
         '7': Waxaan u baahanahay in yar...
         '8': Dhiiranow! Hadda waanu dhownahay.
         '9': Ku dhawaad halkaas...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3899,28 +3921,6 @@ so-SO:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/sq-AL.yml
+++ b/locales/sq-AL.yml
@@ -755,12 +755,18 @@ sq-AL:
   average edits per day:
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -772,12 +778,9 @@ sq-AL:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -785,6 +788,22 @@ sq-AL:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -799,27 +818,10 @@ sq-AL:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back:
+    ceremony:
     episode:
     episode_groups:
     episode_list:
@@ -830,8 +832,6 @@ sq-AL:
     season_list:
     to_tmdb:
     top:
-    award:
-    ceremony:
   certifications:
     certification:
     descriptors:
@@ -2114,6 +2114,7 @@ sq-AL:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2126,7 +2127,6 @@ sq-AL:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3460,6 +3460,22 @@ sq-AL:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3478,6 +3494,9 @@ sq-AL:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3520,6 +3539,9 @@ sq-AL:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3880,28 +3902,6 @@ sq-AL:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/sr-RS.yml
+++ b/locales/sr-RS.yml
@@ -771,12 +771,18 @@ sr-RS:
   average edits per day: просечних уређивања по дану
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -788,12 +794,9 @@ sr-RS:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -801,6 +804,22 @@ sr-RS:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -815,27 +834,10 @@ sr-RS:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Назад
+    ceremony:
     episode: Повратак на епизоду
     episode_groups: Назад на групе епизода
     episode_list: Повратак на листу епизода
@@ -846,8 +848,6 @@ sr-RS:
     season_list: Повратак на листу сезона
     to_tmdb: Назад на ТМДб
     top: Повратак на врх
-    award:
-    ceremony:
   certifications:
     certification: Сертификација
     descriptors:
@@ -2211,6 +2211,7 @@ sr-RS:
       wrong_length:
     movie:
       duplicate_cast: Ова особа је већ додата као члан тима.
+    nesting:
     tv:
       create_season_locked: Креирање нових сезона је закључано за ову серију.
       duplicate_created_by: Ова особа је већ додата као креатор.
@@ -2223,7 +2224,6 @@ sr-RS:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: Ваш e-mail није послат.
   failed_generic: Дошло је до проблема.
@@ -3570,6 +3570,22 @@ sr-RS:
   login_to_edit: Пријави се да направиш измену
   media:
     adult: За одрасле
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Очисти
@@ -3592,6 +3608,9 @@ sr-RS:
           add: Додати филм
           no_records: Нису додати филмови.
       parts: Делови
+    companies:
+      companies:
+      select:
     company:
       headquarters: Седиште
       movie_page_title: Филмове продуцирни од стране %{name}
@@ -3634,6 +3653,9 @@ sr-RS:
         '7': Још само малчице...
         '8': Дотерај то мало! Сада смо баш близу.
         '9': Још само мало...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing: Закључај постојеће наслове
@@ -4028,28 +4050,6 @@ sr-RS:
       published_at: Објављено у
       restricted_regions: Ограничени региони
       tags: Ознаке
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/sv-SE.yml
+++ b/locales/sv-SE.yml
@@ -765,12 +765,18 @@ sv-SE:
   average edits per day: genomsnittliga ändringar per dag
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: Kategorier
       add_category:
       categories:
       category:
@@ -782,12 +788,9 @@ sv-SE:
       locked:
       media_type:
       name:
+      title: Kategorier
     category_empty: Inga nomineringar i denna kategori.
     ceremonies:
-      number: Nummer
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -795,6 +798,22 @@ sv-SE:
       limits:
       location:
       locked:
+      number: Nummer
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -809,27 +828,10 @@ sv-SE:
     title:
     winner: Vinnare
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Tillbaka
+    ceremony:
     episode: Tillbaka till avsnitt
     episode_groups: Tillbaka till avsnittsgrupper
     episode_list: Tillbaka till avsnittslistan
@@ -840,8 +842,6 @@ sv-SE:
     season_list: Tillbaka till säsongerna
     to_tmdb: Tillbaka till TMDB
     top: Tillbaka till toppen
-    award:
-    ceremony:
   certifications:
     certification: Åldersgräns
     descriptors: Deskriptorer
@@ -2199,6 +2199,7 @@ sv-SE:
       wrong_length:
     movie:
       duplicate_cast: Denna personen är redan tillagd som en skådespelare.
+    nesting:
     tv:
       create_season_locked: Skapandet av nya säsonger har låsts för denna serie.
       duplicate_created_by: Den här personen har redan lagts till som en skapare.
@@ -2211,7 +2212,6 @@ sv-SE:
       duplicate_season_episode_crew_member: Den här personen är redan tillagd som %{job_name} till ett avsnitt av den här säsongen. Medarbetare måste läggas till antingen en säsong eller ett avsnitt, och inte båda.
       missing_credit:
       missing_person: Personen du skrev in kunde inte hittas.
-    nesting:
     wrong_count:
   failed_email: Ditt e-postmeddelande skickades tyvärr inte.
   failed_generic: Det uppstod ett problem.
@@ -3550,6 +3550,22 @@ sv-SE:
   login_to_edit: Logga in för att redigera
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Rensa
@@ -3570,6 +3586,9 @@ sv-SE:
           add: Lägg till film
           no_records: Inga filmer har blivit tillagda.
       parts: Delar
+    companies:
+      companies:
+      select:
     company:
       headquarters: Huvudkontor
       movie_page_title: Filmer producerade av %{name}
@@ -3612,6 +3631,9 @@ sv-SE:
         '7': Bara lite till...
         '8':
         '9': Nästan där...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3986,28 +4008,6 @@ sv-SE:
       published_at: Publicerad vid
       restricted_regions: Regionbegränsning
       tags: Taggar
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/ta-IN.yml
+++ b/locales/ta-IN.yml
@@ -779,12 +779,18 @@ ta-IN:
   average edits per day:
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -796,12 +802,9 @@ ta-IN:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -809,6 +812,22 @@ ta-IN:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -823,27 +842,10 @@ ta-IN:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back:
+    ceremony:
     episode:
     episode_groups:
     episode_list:
@@ -854,8 +856,6 @@ ta-IN:
     season_list:
     to_tmdb:
     top:
-    award:
-    ceremony:
   certifications:
     certification:
     descriptors:
@@ -2178,6 +2178,7 @@ ta-IN:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2190,7 +2191,6 @@ ta-IN:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3524,6 +3524,22 @@ ta-IN:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3542,6 +3558,9 @@ ta-IN:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3584,6 +3603,9 @@ ta-IN:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3944,28 +3966,6 @@ ta-IN:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/te-IN.yml
+++ b/locales/te-IN.yml
@@ -789,12 +789,18 @@ te-IN:
   average edits per day:
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -806,12 +812,9 @@ te-IN:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -819,6 +822,22 @@ te-IN:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -833,27 +852,10 @@ te-IN:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: వెనుకకు
+    ceremony:
     episode:
     episode_groups:
     episode_list:
@@ -868,8 +870,6 @@ te-IN:
     top: |2-
 
       తిరిగి పైకి
-    award:
-    ceremony:
   certifications:
     certification:
     descriptors:
@@ -2200,6 +2200,7 @@ te-IN:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2212,7 +2213,6 @@ te-IN:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3548,6 +3548,22 @@ te-IN:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3566,6 +3582,9 @@ te-IN:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3608,6 +3627,9 @@ te-IN:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3968,28 +3990,6 @@ te-IN:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/th-TH.yml
+++ b/locales/th-TH.yml
@@ -763,12 +763,18 @@ th-TH:
   average edits per day: ค่าเฉลี่ยการแก้ไขต่อวัน
   awards:
     add_nomination: เพิ่มรายชื่อผู้เข้าชิง
+    admin:
+      delete:
     air_date:
       future: ออกอากาศวันที่ %{date}
       past: ออกอากาศวันที่ %{date}
     alternative_names: ชื่ออื่น
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: หมวดหมู่
       add_category:
       categories:
       category:
@@ -780,12 +786,9 @@ th-TH:
       locked:
       media_type:
       name:
+      title: หมวดหมู่
     category_empty: ไม่มีการเสนอชื่อสําหรับหมวดหมู่นี้
     ceremonies:
-      number: หมายเลข
-      release_date_max:
-      release_date_min:
-      title: เวที
       add_ceremony:
       ceremonies:
       ceremony:
@@ -793,15 +796,31 @@ th-TH:
       limits:
       location:
       locked:
+      number: หมายเลข
+      release_date_max:
+      release_date_min:
+      title: เวที
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      one: เข้าชิง %{count} สาขา
-      other: เข้าชิง 1 สาขา
       add_nomination:
       locked:
       movie:
       nomination:
       number:
         other:
+      one: เข้าชิง %{count} สาขา
+      other: เข้าชิง 1 สาขา
       title:
     nominee: ผู้เข้าชิง
     show_info:
@@ -818,27 +837,10 @@ th-TH:
     wins:
       one: "%{count} รางวัล"
       other: "%{count} รางวัล"
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: กลับไป
+    ceremony:
     episode:
     episode_groups:
     episode_list: กลับไปยังรายชื่อตอน
@@ -849,8 +851,6 @@ th-TH:
     season_list: กลับไปยังรายชื่อซีซั่น
     to_tmdb: กลับไป TMDB
     top: กลับไปด้านบนสุด
-    award:
-    ceremony:
   certifications:
     certification: การจำกัดอายุ
     descriptors: คำบรรยาย
@@ -2200,6 +2200,7 @@ th-TH:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2212,7 +2213,6 @@ th-TH:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3549,6 +3549,22 @@ th-TH:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3567,6 +3583,9 @@ th-TH:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3609,6 +3628,9 @@ th-TH:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3969,28 +3991,6 @@ th-TH:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/tr-TR.yml
+++ b/locales/tr-TR.yml
@@ -763,12 +763,18 @@ tr-TR:
   average edits per day: günlük ortalama düzenleme sayısı
   awards:
     add_nomination: Aday ekle
+    admin:
+      delete:
     air_date:
       future: Yayınlama %{date}
       past: Yayınlandı %{date}
     alternative_names: Alternatif İsimler
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: Kategoriler
       add_category:
       categories:
       category:
@@ -780,12 +786,9 @@ tr-TR:
       locked:
       media_type:
       name:
+      title: Kategoriler
     category_empty: Bu kategori için aday yok.
     ceremonies:
-      number: Sayı
-      release_date_max: Maksimum Çıkış Tarihi
-      release_date_min: Minimum Çıkış Tarihi
-      title: Törenler
       add_ceremony:
       ceremonies:
       ceremony:
@@ -793,9 +796,23 @@ tr-TR:
       limits:
       location:
       locked:
+      number: Sayı
+      release_date_max: Maksimum Çıkış Tarihi
+      release_date_min: Minimum Çıkış Tarihi
+      title: Törenler
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      one: "%{count} Aday"
-      other: 1 Aday
       add_nomination:
       locked:
       movie:
@@ -803,6 +820,8 @@ tr-TR:
       number:
         one:
         other:
+      one: "%{count} Aday"
+      other: 1 Aday
       title:
     nominee: Aday
     show_info:
@@ -819,27 +838,10 @@ tr-TR:
     wins:
       one: "%{count} Kazanılan"
       other: 1 Kazanılan
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Geri
+    ceremony:
     episode: Bölüme Geri Dön
     episode_groups: Bölüm gruplarına geri dön
     episode_list: Bölüm listesine geri dön
@@ -850,8 +852,6 @@ tr-TR:
     season_list: Sezon listesine geri dön
     to_tmdb: TMDb'ye Geri Dön
     top: Başa Dön
-    award:
-    ceremony:
   certifications:
     certification: Sertifikasyon
     descriptors: Tanımlayıcılar
@@ -2194,6 +2194,7 @@ tr-TR:
       wrong_length: yanlış uzunluk (%{count} karakter olmalıdır)
     movie:
       duplicate_cast: Bu kişi daha önce oyuncu olarak eklenmiş.
+    nesting:
     tv:
       create_season_locked: Bu dizi için yeni sezonların yaratılması kilitlendi.
       duplicate_created_by: Bu kişi zaten bir içerik oluşturucu olarak eklenmiş.
@@ -2206,7 +2207,6 @@ tr-TR:
       duplicate_season_episode_crew_member: Bu kişi zaten bu sezonun bir bölümüne %{job_name} olarak eklendi. Ekip jeneriklerinin bir sezona veya bir bölüme eklenmesi gerekir; her ikisine birden eklenmesi gerekmez.
       missing_credit: Düzenlemeye çalıştığınız jenerik mevcut değil.
       missing_person: Girdiğiniz kişi bulunamadı.
-    nesting:
     wrong_count:
   failed_email: E-Mail adresinize gönderilemedi
   failed_generic: Bir problem oluştu.
@@ -3551,6 +3551,22 @@ tr-TR:
   login_to_edit: Düzenlemek için oturum aç
   media:
     adult: Yetişkin
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Temizle
@@ -3571,6 +3587,9 @@ tr-TR:
           add: Film Ekle
           no_records: Hiçbir film eklenmemiş.
       parts: Filmler
+    companies:
+      companies:
+      select:
     company:
       headquarters: Genel Merkez
       movie_page_title: "%{name} tarafından çekilen filmler"
@@ -3613,6 +3632,9 @@ tr-TR:
         '7': Biraz daha sabır...
         '8': Ha gayret az kaldı.
         '9': Neredeyse bitti...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing: Mevcut Başlıkları Kilitle
@@ -3991,28 +4013,6 @@ tr-TR:
       published_at: Yayınlanma Tarihi
       restricted_regions: Kısıtlı Bölgeler
       tags: Etiketler
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/uk-UA.yml
+++ b/locales/uk-UA.yml
@@ -780,12 +780,18 @@ uk-UA:
   average edits per day: у середньому змін на день
   awards:
     add_nomination: Додати номінацію
+    admin:
+      delete:
     air_date:
       future: Відбудеться %{date}
       past: Відбулося %{date}
     alternative_names: Альтернативні назви
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: Категорії
       add_category:
       categories:
       category:
@@ -797,12 +803,9 @@ uk-UA:
       locked:
       media_type:
       name:
+      title: Категорії
     category_empty: У цій категорії відсутні номінації.
     ceremonies:
-      number: Номер
-      release_date_max: Дата випуску Макс
-      release_date_min: Дата випуску Мін
-      title: Церемонії
       add_ceremony:
       ceremonies:
       ceremony:
@@ -810,20 +813,36 @@ uk-UA:
       limits:
       location:
       locked:
+      number: Номер
+      release_date_max: Дата випуску Макс
+      release_date_min: Дата випуску Мін
+      title: Церемонії
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      few: "%{count} номінації"
-      many: "%{count} номінації"
-      one: 1 номінація
-      other: "%{count} номінацій"
       add_nomination:
+      few: "%{count} номінації"
       locked:
+      many: "%{count} номінації"
       movie:
       nomination:
       number:
-        one:
         few:
         many:
+        one:
         other:
+      one: 1 номінація
+      other: "%{count} номінацій"
       title:
     nominee: Номінант
     show_info:
@@ -842,27 +861,10 @@ uk-UA:
       many: "%{count} перемоги"
       one: 1 перемога
       other: "%{count} перемог"
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Назад
+    ceremony:
     episode: Повернутися до серії
     episode_groups: Повернутися до груп серій
     episode_list: Повернутися до списку серій
@@ -873,8 +875,6 @@ uk-UA:
     season_list: Повернутися до списку сезонів
     to_tmdb: Повернутися до TMDB
     top: Повернутися наверх
-    award:
-    ceremony:
   certifications:
     certification: Сертифікація
     descriptors: Опис
@@ -2277,6 +2277,7 @@ uk-UA:
         other: неправильної довжини (має бути %{count} символів)
     movie:
       duplicate_cast: Ця персона вже додана як член акторського складу.
+    nesting:
     tv:
       create_season_locked: 'Додавання нового сезону для цього серіалу заблоковано. '
       duplicate_created_by: Ця персона вже додана як творець.
@@ -2289,7 +2290,6 @@ uk-UA:
       duplicate_season_episode_crew_member: Ця персона вже додана як %{job_name} до одного з епізодів цього сезону. Титри знімальної групи потрібно додавати або до сезону, або до епізоду, але не до обох.
       missing_credit: Титр, який ви намагалися відредагувати, не існує.
       missing_person: Введену персону не вдалося знайти.
-    nesting:
     wrong_count:
   failed_email: 'Не вдалося надіслати ваш лист. '
   failed_generic: 'Виникла проблема. '
@@ -3641,6 +3641,22 @@ uk-UA:
   login_to_edit: Увійдіть, щоб редагувати
   media:
     adult: Для дорослих
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Очистити
@@ -3663,6 +3679,9 @@ uk-UA:
           add: Додати фільм
           no_records: 'Не додано жодного фільму. '
       parts: Частини
+    companies:
+      companies:
+      select:
     company:
       headquarters: Штаб-квартира
       movie_page_title: Фільми виробництва %{name}
@@ -3705,6 +3724,9 @@ uk-UA:
         '7': Ще трішечки…
         '8': Долийте! Чогось бракує.
         '9': Майже як треба…
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing: Заблокувати наявні назви
@@ -4099,28 +4121,6 @@ uk-UA:
       published_at: Опубліковано
       restricted_regions: Заборонені регіони
       tags: Теги
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/uz-UZ.yml
+++ b/locales/uz-UZ.yml
@@ -758,12 +758,18 @@ uz-UZ:
   average edits per day:
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -775,12 +781,9 @@ uz-UZ:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -788,6 +791,22 @@ uz-UZ:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -802,27 +821,10 @@ uz-UZ:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back:
+    ceremony:
     episode:
     episode_groups:
     episode_list:
@@ -833,8 +835,6 @@ uz-UZ:
     season_list:
     to_tmdb:
     top:
-    award:
-    ceremony:
   certifications:
     certification:
     descriptors:
@@ -2117,6 +2117,7 @@ uz-UZ:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2129,7 +2130,6 @@ uz-UZ:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3463,6 +3463,22 @@ uz-UZ:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: Tozalash
@@ -3483,6 +3499,9 @@ uz-UZ:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3525,6 +3544,9 @@ uz-UZ:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3885,28 +3907,6 @@ uz-UZ:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/vi-VN.yml
+++ b/locales/vi-VN.yml
@@ -757,12 +757,18 @@ vi-VN:
   average edits per day: Số lần chỉnh sửa trung bình mỗi ngày
   awards:
     add_nomination: Thêm đề cử
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names: Tên thay thế
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: Thể loại
       add_category:
       categories:
       category:
@@ -774,12 +780,9 @@ vi-VN:
       locked:
       media_type:
       name:
+      title: Thể loại
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -787,15 +790,31 @@ vi-VN:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      one: "%{count} Đề cử"
-      other: 1 Đề cử
       add_nomination:
       locked:
       movie:
       nomination:
       number:
         other:
+      one: "%{count} Đề cử"
+      other: 1 Đề cử
       title:
     nominee:
     show_info:
@@ -810,27 +829,10 @@ vi-VN:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: Quay lại
+    ceremony:
     episode:
     episode_groups:
     episode_list:
@@ -841,8 +843,6 @@ vi-VN:
     season_list: Quay lại danh sách phần
     to_tmdb: Quay lại TMDB
     top: Quay lại trên cùng
-    award:
-    ceremony:
   certifications:
     certification:
     descriptors:
@@ -2125,6 +2125,7 @@ vi-VN:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2137,7 +2138,6 @@ vi-VN:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3471,6 +3471,22 @@ vi-VN:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3489,6 +3505,9 @@ vi-VN:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3531,6 +3550,9 @@ vi-VN:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3891,28 +3913,6 @@ vi-VN:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -763,12 +763,18 @@ zh-CN:
   average edits per day: 日均编辑量
   awards:
     add_nomination: 添加提名
+    admin:
+      delete:
     air_date:
       future: 播出日期 %{date}
       past: 播出时间 %{date}
     alternative_names: 其他名称
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: 分类
       add_category:
       categories:
       category:
@@ -780,12 +786,9 @@ zh-CN:
       locked:
       media_type:
       name:
+      title: 分类
     category_empty: 该分类无提名
     ceremonies:
-      number: 编号
-      release_date_max: 上映日期上限
-      release_date_min: 上映日期下限
-      title: 典礼
       add_ceremony:
       ceremonies:
       ceremony:
@@ -793,15 +796,31 @@ zh-CN:
       limits:
       location:
       locked:
+      number: 编号
+      release_date_max: 上映日期上限
+      release_date_min: 上映日期下限
+      title: 典礼
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      one: 1项提名
-      other: "%{count} 项提名"
       add_nomination:
       locked:
       movie:
       nomination:
       number:
         other:
+      one: 1项提名
+      other: "%{count} 项提名"
       title:
     nominee: 提名
     show_info:
@@ -818,27 +837,10 @@ zh-CN:
     wins:
       one: 1 项获奖
       other: "%{count} 项获奖"
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: 返回
+    ceremony:
     episode: 返回集
     episode_groups: 返回剧集组
     episode_list: 返回集列表
@@ -849,8 +851,6 @@ zh-CN:
     season_list: 返回季列表
     to_tmdb: 返回TMDB
     top: 返回顶部
-    award:
-    ceremony:
   certifications:
     certification: 分级
     descriptors: 描述符
@@ -2211,6 +2211,7 @@ zh-CN:
       wrong_length: 长度错误 (应当为%{count}字符)
     movie:
       duplicate_cast: 此人物已添加为演员。
+    nesting:
     tv:
       create_season_locked: 此剧集已被锁定无法添加新季。
       duplicate_created_by: 此人员已添加为创作者。
@@ -2223,7 +2224,6 @@ zh-CN:
       duplicate_season_episode_crew_member: 此人已作为 %{job_name} 添加到本季的剧集中。 剧组人员名单需要添加到一季或一集中，而不是两处都添加。
       missing_credit: 您尝试编辑的名单不存在。
       missing_person: 找不到您输入的人物。
-    nesting:
     wrong_count:
   failed_email: 邮件发送失败
   failed_generic: 出现问题。
@@ -3568,6 +3568,22 @@ zh-CN:
   login_to_edit: 登录以编辑
   media:
     adult: 成人
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: 清除
@@ -3588,6 +3604,9 @@ zh-CN:
           add: 添加电影
           no_records: 尚未添加电影。
       parts: 内含电影
+    companies:
+      companies:
+      select:
     company:
       headquarters: 总部
       movie_page_title: "%{name} 制作的电影"
@@ -3630,6 +3649,9 @@ zh-CN:
         '7': 只差一点点...
         '8': 加油！成功就在眼前。
         '9': 马上要完成了...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing: 锁定现有标题
@@ -4008,28 +4030,6 @@ zh-CN:
       published_at: 发布于
       restricted_regions: 限制区域
       tags: 标签
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/zh-HK.yml
+++ b/locales/zh-HK.yml
@@ -761,12 +761,18 @@ zh-HK:
   average edits per day: 每日平均編輯量
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -778,12 +784,9 @@ zh-HK:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -791,6 +794,22 @@ zh-HK:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -805,27 +824,10 @@ zh-HK:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: 返回
+    ceremony:
     episode: 回到集數
     episode_groups: 回到集數群
     episode_list: 回到集數清單
@@ -836,8 +838,6 @@ zh-HK:
     season_list: 回到影集清單
     to_tmdb: 返回至 TMDB
     top: 回到開頭頁
-    award:
-    ceremony:
   certifications:
     certification: 分級
     descriptors:
@@ -2185,6 +2185,7 @@ zh-HK:
       wrong_length:
     movie:
       duplicate_cast: 已存在於演員群中
+    nesting:
     tv:
       create_season_locked: 已封鎖建立此影集的新季數的設定。
       duplicate_created_by: 已存在於導演群中
@@ -2197,7 +2198,6 @@ zh-HK:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: 郵件傳送錯誤
   failed_generic: 發生了問題
@@ -3531,6 +3531,22 @@ zh-HK:
   login_to_edit: 登入編輯
   media:
     adult: 成人
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: 清除
@@ -3551,6 +3567,9 @@ zh-HK:
           add: 新增電影
           no_records: 沒有添加的電影。
       parts: 部分
+    companies:
+      companies:
+      select:
     company:
       headquarters: 總部
       movie_page_title: 此電影由 %{name} 製作
@@ -3593,6 +3612,9 @@ zh-HK:
         '7': 還有一點點⋯
         '8': 完成！
         '9': 幾乎要完成了⋯
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3961,28 +3983,6 @@ zh-HK:
       published_at: 發佈時間為
       restricted_regions: 限制區域
       tags: 標籤
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/zh-SG.yml
+++ b/locales/zh-SG.yml
@@ -755,12 +755,18 @@ zh-SG:
   average edits per day:
   awards:
     add_nomination:
+    admin:
+      delete:
     air_date:
       future:
       past:
     alternative_names:
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title:
       add_category:
       categories:
       category:
@@ -772,12 +778,9 @@ zh-SG:
       locked:
       media_type:
       name:
+      title:
     category_empty:
     ceremonies:
-      number:
-      release_date_max:
-      release_date_min:
-      title:
       add_ceremony:
       ceremonies:
       ceremony:
@@ -785,6 +788,22 @@ zh-SG:
       limits:
       location:
       locked:
+      number:
+      release_date_max:
+      release_date_min:
+      title:
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
     nominee:
     show_info:
@@ -799,27 +818,10 @@ zh-SG:
     title:
     winner:
     wins:
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back:
+    ceremony:
     episode:
     episode_groups:
     episode_list:
@@ -830,8 +832,6 @@ zh-SG:
     season_list:
     to_tmdb:
     top:
-    award:
-    ceremony:
   certifications:
     certification:
     descriptors:
@@ -2114,6 +2114,7 @@ zh-SG:
       wrong_length:
     movie:
       duplicate_cast:
+    nesting:
     tv:
       create_season_locked:
       duplicate_created_by:
@@ -2126,7 +2127,6 @@ zh-SG:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email:
   failed_generic:
@@ -3460,6 +3460,22 @@ zh-SG:
   login_to_edit:
   media:
     adult:
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear:
@@ -3478,6 +3494,9 @@ zh-SG:
           add:
           no_records:
       parts:
+    companies:
+      companies:
+      select:
     company:
       headquarters:
       movie_page_title:
@@ -3520,6 +3539,9 @@ zh-SG:
         '7':
         '8':
         '9':
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3880,28 +3902,6 @@ zh-SG:
       published_at:
       restricted_regions:
       tags:
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/locales/zh-TW.yml
+++ b/locales/zh-TW.yml
@@ -763,12 +763,18 @@ zh-TW:
   average edits per day: 每日平均編輯數量
   awards:
     add_nomination: 新增提名
+    admin:
+      delete:
     air_date:
       future: 將於 %{date} 播出
       past: 已於 %{date} 播出
     alternative_names: 替代名稱
+    award:
+    broadcast_episode:
+    broadcast_episode_tooltip:
+    broadcast_series:
+    broadcast_series_tooltip:
     categories:
-      title: 類別
       add_category:
       categories:
       category:
@@ -780,12 +786,9 @@ zh-TW:
       locked:
       media_type:
       name:
+      title: 類別
     category_empty: 此類別尚無提名。
     ceremonies:
-      number: 次數
-      release_date_max: 上映日期上限
-      release_date_min: 上映日期下限
-      title: 典禮
       add_ceremony:
       ceremonies:
       ceremony:
@@ -793,15 +796,31 @@ zh-TW:
       limits:
       location:
       locked:
+      number: 次數
+      release_date_max: 上映日期上限
+      release_date_min: 上映日期下限
+      title: 典禮
+    field:
+      homepage:
+      name:
+      overview:
+    new_award:
+      award_details:
+      click_next:
+      getting_started:
+      header_1:
+      header_2:
+      note:
+      verify:
     nominations:
-      one: 1 項提名
-      other: "%{count} 項提名"
       add_nomination:
       locked:
       movie:
       nomination:
       number:
         other:
+      one: 1 項提名
+      other: "%{count} 項提名"
       title:
     nominee: 被提名者
     show_info:
@@ -818,27 +837,10 @@ zh-TW:
     wins:
       one: "%{count} 項獲獎"
       other: 1 項獲獎
-    award:
-    broadcast_episode:
-    broadcast_episode_tooltip:
-    broadcast_series:
-    broadcast_series_tooltip:
-    field:
-      homepage:
-      name:
-      overview:
-    new_award:
-      award_details:
-      click_next:
-      getting_started:
-      header_1:
-      header_2:
-      note:
-      verify:
-    admin:
-      delete:
   back_options:
+    award:
     back: 返回
+    ceremony:
     episode: 回到集數
     episode_groups: 回到集數群組
     episode_list: 回到集數清單
@@ -849,8 +851,6 @@ zh-TW:
     season_list: 回到季數清單
     to_tmdb: 回到 TMDB
     top: 回到頂部
-    award:
-    ceremony:
   certifications:
     certification: 分級
     descriptors: 描述詞
@@ -2204,6 +2204,7 @@ zh-TW:
       wrong_length:
     movie:
       duplicate_cast: 此人已存在於演員群組中。
+    nesting:
     tv:
       create_season_locked: 已封鎖建立此影集的新季數的設定。
       duplicate_created_by: 此人已新增為創作人。
@@ -2216,7 +2217,6 @@ zh-TW:
       duplicate_season_episode_crew_member:
       missing_credit:
       missing_person:
-    nesting:
     wrong_count:
   failed_email: 郵件傳送錯誤
   failed_generic: 發生了問題
@@ -3555,6 +3555,22 @@ zh-TW:
   login_to_edit: 登入編輯
   media:
     adult: 成人
+    alternative_names:
+      add_name:
+      alternative_names:
+      name:
+      no_records:
+    award:
+      edit:
+        adult:
+          adult_award:
+        title_logos:
+      header:
+        latest_ceremony:
+        upcoming_ceremony:
+    cast_credits:
+      cast_credits:
+      select:
     changes:
       filters:
         clear: 清除
@@ -3575,6 +3591,9 @@ zh-TW:
           add: 新增電影
           no_records: 沒有添加的電影。
       parts: 部分
+    companies:
+      companies:
+      select:
     company:
       headquarters: 總部
       movie_page_title: "%{name} 製作的電影"
@@ -3617,6 +3636,9 @@ zh-TW:
         '7': 還有一點點...
         '8': 加油！接近終點了。
         '9': 幾乎要完成了...
+    crew_credits:
+      crew_credits:
+      select:
     edit:
       alternative_title:
         lock_existing:
@@ -3995,28 +4017,6 @@ zh-TW:
       published_at: 發佈時間為
       restricted_regions: 限制區域
       tags: 標籤
-    alternative_names:
-      add_name:
-      alternative_names:
-      name:
-      no_records:
-    award:
-      edit:
-        adult:
-          adult_award:
-        title_logos:
-      header:
-        latest_ceremony:
-        upcoming_ceremony:
-    cast_credits:
-      cast_credits:
-      select:
-    companies:
-      companies:
-      select:
-    crew_credits:
-      crew_credits:
-      select:
     wizard:
       award_details:
       getting_started:

--- a/script/sort.rb
+++ b/script/sort.rb
@@ -1,0 +1,46 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+
+require "tempfile"
+require "yaml"
+
+at_exit do
+  each_yaml(ARGV) do |file_path, yaml|
+    sorted_yaml = deep_sort_keys(yaml)
+
+    abort "YAML structure changed in #{file_path}!" unless yaml == sorted_yaml
+
+    sorted_yaml
+  end
+end
+
+def deep_sort_keys(obj, new_obj = {})
+  obj.each do |key, value|
+    if value.is_a?(Hash)
+      new_obj[key] = deep_sort_keys(value, {}).sort.to_h
+    else
+      new_obj[key] = value
+    end
+  end
+
+  new_obj
+end
+
+def each_yaml(paths, &block)
+  yaml_files = paths.flat_map { |file_name|
+    File.directory?(file_name) ? Dir.glob(File.join(file_name, "**/*.yml")) : file_name
+  }
+
+  yaml_files.each do |file_path|
+    yaml = YAML.load_file(file_path)
+    new_yaml = yield file_path, yaml
+
+    tempfile = Tempfile.create(File.basename(file_path))
+    tempfile.write(YAML.dump(new_yaml, line_width: -1))
+
+    File.unlink(file_path)
+    File.link(tempfile.path, file_path)
+  end
+end

--- a/script/split.rb
+++ b/script/split.rb
@@ -1,0 +1,49 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+
+require "optparse"
+require "tempfile"
+require "yaml"
+
+# Usage:
+# ruby script/sort.rb --sort-keys ~/Downloads/i18n_locales.yml
+
+OptionParser.new do |parser|
+  parser.banner = "Usage: #{$PROGRAM_NAME} [options]"
+  parser.on("-s", "--sort-keys") do
+    @sort = true
+  end
+end.parse!
+
+at_exit do
+  source_path = ARGV.shift
+  abort if source_path.nil? || source_path.empty?
+
+  data = YAML.load_file(source_path)
+  data.each do |locale, translations|
+    data = { locale => translations }
+    data = deep_sort_keys(data) if @sort
+
+    file_path = "locales/#{locale}.yml"
+
+    tempfile = Tempfile.create(File.basename(file_path))
+    tempfile.write(YAML.dump(data, line_width: -1))
+
+    File.unlink(file_path)
+    File.link(tempfile.path, file_path)
+  end
+end
+
+def deep_sort_keys(obj, new_obj = {})
+  obj.each do |key, value|
+    if value.is_a?(Hash)
+      new_obj[key] = deep_sort_keys(value, {}).sort.to_h
+    else
+      new_obj[key] = value
+    end
+  end
+
+  new_obj
+end


### PR DESCRIPTION
**What does this do?**
This "deep alphabetizes" the keys in `locales/*.yml` and compares the resulting hash to the original to verify they are equivalent. The sort script is included so we can keep files organized even when new keys are patched in.

```
# To sort all locales:
$ script/sort.rb locales/

# To sort a single locale:
$ script/sort.rb locales/en-US.yml

# To split an export
$ script/split.rb --sort-keys ~/Downloads/i18n_export.yml
```

**Why is this important?**
The new UI translation system being built into TMDB will need to export YAML files after the community has made updates to the translations. By keeping the keys alphabetized (at every depth), we can be more confident that the diffs in a PR can be understood and merged.