### PR TITLE
feat: update and normalize language list

### DIFF
--- a/languages/pt-PT.yml
+++ b/languages/pt-PT.yml
@@ -11,17 +11,17 @@
     an: Aragonês
     hy: Arménio
     as: Assamês
-    av: Arábico
+    av: Avárico
     ae: Avéstico
     ay: Aimará
     az: Azerbaijano
-    ba: Basquir
+    ba: Bashkir
     bm: Bambara
     eu: Basco
     be: Bielorrusso
     bn: Bengalês
-    bh: Línguas Biaris
-    bi: Bislamá
+    bh: Línguas biáris
+    bi: Bislama
     bs: Bósnio
     br: Bretão
     bg: Búlgaro
@@ -30,7 +30,7 @@
     ch: Chamorro
     ce: Checheno
     zh: Chinês
-    cu: Antigo Eslavo Eclesiástico
+    cu: Antigo eslavónico eclesiástico
     cv: Chuvache
     kw: Córnico
     co: Corso
@@ -39,28 +39,28 @@
     da: Dinamarquês
     dv: Divehi
     nl: Neerlandês
-    dz: Zoncá
+    dz: Zoncá (Dzongkha)
     en: Inglês
     eo: Esperanto
-    et: Estoniano
-    ee: Jeje
+    et: Estónio
+    ee: Eve
     fo: Feroês
     fj: Fijiano
     fi: Finlandês
     fr: Francês
-    fy: Frísico Ocidental
+    fy: Frísico ocidental
     ff: Fula
     ka: Georgiano
     de: Alemão
-    gd: Gaélico Escocês
+    gd: Gaélico escocês
     ga: Irlandês
     gl: Galego
     gv: Manês
-    el: Grego Moderno (1453-)
+    el: Grego moderno
     gn: Guarani
     gu: Guzerate
     ht: Haitiano
-    ha: Haúça
+    ha: Hauçá
     he: Hebraico
     hz: Herero
     hi: Hindi
@@ -70,26 +70,26 @@
     ig: Igbo
     is: Islandês
     io: Ido
-    ii: Nuossu
+    ii: Nuosu
     iu: Inuktitut
-    ie: Interlingue (Occidental)
-    ia: Interlíngua (International Auxiliary Language Association)
+    ie: Interlíngue
+    ia: Interlíngua
     id: Indonésio
     ik: Inupiaque
     it: Italiano
     jv: Javanês
     ja: Japonês
     kl: Groenlandês
-    kn: Canarim
+    kn: Canarim (Kannada)
     ks: Caxemira
-    kr: Canúri
+    kr: Kanuri
     kk: Cazaque
     km: Khmer
     ki: Quicuio
     rw: Quiniaruanda
     ky: Quirguiz
     kv: Komi
-    kg: Quicongo
+    kg: Kongo
     ko: Coreano
     kj: Cuanhama
     ku: Curdo
@@ -100,7 +100,7 @@
     ln: Lingala
     lt: Lituano
     lb: Luxemburguês
-    lu: Luba-Katanga (Kiluba)
+    lu: Luba-Katanga
     lg: Luganda
     mk: Macedónio
     mh: Marshallês
@@ -110,33 +110,33 @@
     ms: Malaio
     mg: Malgaxe
     mt: Maltês
-    mo: Romeno (Moldávia)
+    mo: Moldavo (obsoleto — substituído por Romeno)
     mn: Mongol
     na: Nauruano
-    nv: Navajo; Navaho
+    nv: Navajo
     nr: Ndebele do Sul
     nd: Ndebele do Norte
     ng: Ndonga
     ne: Nepalês
     nn: Norueguês Nynorsk
     nb: Norueguês Bokmål
-    'no': Norueguês
+    no: Norueguês
     ny: Nianja
     oc: Occitano
-    oj: Chippewa (Ojíbua)
-    or: Oriá
+    oj: Ojíbua
+    or: Odia
     om: Oromo
-    os: Ossetiano
-    pa: Panjabi
+    os: Osseta
+    pa: Punjabi
     fa: Persa
     pi: Páli
     pl: Polaco
     pt: Português
-    ps: Pastó
+    ps: Pashto
     qu: Quíchua
     rm: Romanche
     ro: Romeno
-    rn: Kirundi (Rundi)
+    rn: Kirundi
     ru: Russo
     sg: Sango
     sa: Sânscrito
@@ -146,7 +146,7 @@
     se: Sami do Norte
     sm: Samoano
     sn: Shona
-    sd: Síndico
+    sd: Sindi
     so: Somali
     st: Soto do Sul
     es: Espanhol
@@ -184,5 +184,5 @@
     xh: Xosa
     yi: Iídiche
     yo: Ioruba
-    za: Zhuang (Chuang)
+    za: Zhuang
     zu: Zulu


### PR DESCRIPTION
Overhaul language definitions:
– Updated all pt-PT language names (AO90)
– Normalized to ISO 639-1 standards
– Added note for obsolete code “mo” (Moldovan → replaced by Romanian)