### PR TITLE
Fix reviews fields for German translation

### DIFF
--- a/locales/de-DE.yml
+++ b/locales/de-DE.yml
@@ -527,7 +527,7 @@ de-DE:
     sign_up: Registrieren
     view_profile: Profil ansehen
     watchlist: Watchliste
-    reviews:
+    reviews: Rezensionen
   accounts:
     activity:
       activity: Aktivitäten
@@ -647,9 +647,9 @@ de-DE:
       lists: Listen
       overview: Übersicht
       ratings: Bewertungen
-      ratings_reviews: Bewertungen & Rezessionen
+      ratings_reviews: Bewertungen & Rezensionen
       recommendations: Empfehlungen
-      reviews: Rezessionen
+      reviews: Rezensionen
       watchlist: Watchliste
     order: 'Sortierung:'
     overview:
@@ -679,8 +679,8 @@ de-DE:
         logged_in: Meine Bewertungen
         public: "%{username}'s Bewertungen"
       my_reviews:
-        logged_in: Meine Rezessionen
-        public: "%{username}'s Rezessionen"
+        logged_in: Meine Rezensionen
+        public: "%{username}'s Rezensionen"
       page_title:
         page_owner: Meine Bewertungen & Rezensionen
         public: "%{username}'s Bewertungen & Rezensionen"


### PR DESCRIPTION
"Rezessionen" = recessions
"Rezensionen" = reviews